### PR TITLE
Config type array instead of object

### DIFF
--- a/src/Config/Factory/ModuleConfigFactory.php
+++ b/src/Config/Factory/ModuleConfigFactory.php
@@ -4,7 +4,6 @@ namespace Reinfi\DependencyInjection\Config\Factory;
 
 use Psr\Container\ContainerInterface;
 use Reinfi\DependencyInjection\Config\ModuleConfig;
-use Zend\Config\Config;
 
 /**
  * @package Reinfi\DependencyInjection\Config\Factory
@@ -14,23 +13,20 @@ class ModuleConfigFactory
     /**
      * @param ContainerInterface $container
      *
-     * @return Config
+     * @return array
      * @throws \InvalidArgumentException
      */
-    public function __invoke(ContainerInterface $container): Config
+    public function __invoke(ContainerInterface $container): array
     {
-        $config = new Config($container->get('config'));
+        /** @var array $config */
+        $config = $container->get('config');
 
-        if ($config->offsetExists(ModuleConfig::CONFIG_KEY)) {
-            $moduleConfig = $config->get(ModuleConfig::CONFIG_KEY);
+        $moduleConfig = $config[ModuleConfig::CONFIG_KEY] ?? [];
 
-            if (!$moduleConfig instanceof Config) {
-                throw new \InvalidArgumentException('Module config must be type of ' . Config::class);
-            }
-
-            return $moduleConfig;
+        if (!is_array($moduleConfig)) {
+            throw new \InvalidArgumentException('Module config must be type of array');
         }
 
-        return new Config([]);
+        return $moduleConfig;
     }
 }

--- a/src/Service/AutoWiring/Factory/ResolverServiceFactory.php
+++ b/src/Service/AutoWiring/Factory/ResolverServiceFactory.php
@@ -10,7 +10,6 @@ use Reinfi\DependencyInjection\Service\AutoWiring\Resolver\PluginManagerResolver
 use Reinfi\DependencyInjection\Service\AutoWiring\Resolver\RequestResolver;
 use Reinfi\DependencyInjection\Service\AutoWiring\Resolver\ResponseResolver;
 use Reinfi\DependencyInjection\Service\AutoWiring\ResolverService;
-use Zend\Config\Config;
 
 /**
  * @package Reinfi\DependencyInjection\Service\AutoWiring\Factory
@@ -24,46 +23,42 @@ class ResolverServiceFactory
      */
     public function __invoke(ContainerInterface $container): ResolverService
     {
-        /** @var Config $config */
+        /** @var array $config */
         $config = $container->get(ModuleConfig::class);
 
         $resolverStackConfig = $this->getResolverStack($config);
 
         $resolverStack = array_map(
             [$container, 'get'],
-            $resolverStackConfig->toArray()
+            $resolverStackConfig
         );
 
         return new ResolverService($resolverStack);
     }
 
     /**
-     * @param Config $config
+     * @param array $config
      *
-     * @return Config
+     * @return array
      */
-    protected function getResolverStack(Config $config): Config
+    protected function getResolverStack(array $config): array
     {
-        $defaultResolverStackConfig = new Config(
-            [
-                ContainerResolver::class,
-                PluginManagerResolver::class,
-                ContainerInterfaceResolver::class,
-                RequestResolver::class,
-                ResponseResolver::class,
-            ]
-        );
+        $defaultResolverStackConfig = [
+            ContainerResolver::class,
+            PluginManagerResolver::class,
+            ContainerInterfaceResolver::class,
+            RequestResolver::class,
+            ResponseResolver::class,
+        ];
 
-        /** @var Config $resolverStackConfig */
-        $resolverStackConfig = $config->get('autowire_resolver');
+        $resolverStackConfig = $config['autowire_resolver'] ?? null;
         if ($resolverStackConfig === null) {
             return $defaultResolverStackConfig;
         }
 
-        $resolverStackConfig = $defaultResolverStackConfig->merge(
+        return array_merge(
+            $defaultResolverStackConfig,
             $resolverStackConfig
         );
-
-        return $resolverStackConfig;
     }
 }

--- a/src/Service/Extractor/Factory/ExtractorFactory.php
+++ b/src/Service/Extractor/Factory/ExtractorFactory.php
@@ -6,7 +6,6 @@ use Psr\Container\ContainerInterface;
 use Reinfi\DependencyInjection\Config\ModuleConfig;
 use Reinfi\DependencyInjection\Service\Extractor\AnnotationExtractor;
 use Reinfi\DependencyInjection\Service\Extractor\ExtractorInterface;
-use Zend\Config\Config;
 
 /**
  * @package Reinfi\DependencyInjection\Service\Extractor\Factory
@@ -20,11 +19,13 @@ class ExtractorFactory
      */
     public function __invoke(ContainerInterface $container): ExtractorInterface
     {
-        /** @var Config $config */
+        /** @var array $config */
         $config = $container->get(ModuleConfig::class);
 
         /** @var ExtractorInterface $extractor */
-        $extractor = $container->get($config->get('extractor', AnnotationExtractor::class));
+        $extractor = $container->get(
+            $config['extractor'] ?? AnnotationExtractor::class
+        );
 
         return $extractor;
     }

--- a/src/Service/Extractor/Factory/YamlExtractorFactory.php
+++ b/src/Service/Extractor/Factory/YamlExtractorFactory.php
@@ -7,7 +7,6 @@ use Reinfi\DependencyInjection\Annotation\AnnotationInterface;
 use Reinfi\DependencyInjection\Config\ModuleConfig;
 use Reinfi\DependencyInjection\Service\Extractor\YamlExtractor;
 use Symfony\Component\Yaml\Yaml;
-use Zend\Config\Config;
 
 /**
  * @package Reinfi\DependencyInjection\Service\Extractor\Factory
@@ -23,14 +22,14 @@ class YamlExtractorFactory
     {
         $yaml = new Yaml();
 
-        /** @var Config $config */
+        /** @var array $config */
         $config = $container->get(ModuleConfig::class);
 
         $reflClass = new \ReflectionClass(AnnotationInterface::class);
 
         return new YamlExtractor(
             $yaml,
-            $config->extractor_options->file,
+            $config['extractor_options']['file'],
             $reflClass->getNamespaceName()
         );
     }

--- a/src/Service/Factory/CacheServiceFactory.php
+++ b/src/Service/Factory/CacheServiceFactory.php
@@ -7,7 +7,6 @@ use Reinfi\DependencyInjection\Config\ModuleConfig;
 use Reinfi\DependencyInjection\Service\CacheService;
 use Zend\Cache\Storage\Adapter\Memory;
 use Zend\Cache\StorageFactory;
-use Zend\Config\Config;
 
 /**
  * @package Reinfi\DependencyInjection\Service\Factory
@@ -21,20 +20,14 @@ class CacheServiceFactory
      */
     public function __invoke(ContainerInterface $container): CacheService
     {
-        /** @var Config $config */
+        /** @var array $config */
         $config = $container->get(ModuleConfig::class);
 
-        $cacheAdapter = $config->get('cache', Memory::class);
+        $cacheAdapter = $config['cache'] ?? Memory::class;
 
-        $cacheOptions = $config->get('cache_options', []);
-        if ($cacheOptions instanceof Config) {
-            $cacheOptions = $cacheOptions->toArray();
-        }
+        $cacheOptions = $config['cache_options'] ?? [];
 
-        $cachePlugins = $config->get('cache_plugins', []);
-        if ($cachePlugins instanceof Config) {
-            $cachePlugins = $cachePlugins->toArray();
-        }
+        $cachePlugins = $config['cache_plugins'] ?? [];
 
         $cache = StorageFactory::factory(
             [

--- a/test/Unit/Config/Factory/ModuleConfigFactoryTest.php
+++ b/test/Unit/Config/Factory/ModuleConfigFactoryTest.php
@@ -24,10 +24,10 @@ class ModuleConfigFactoryTest extends TestCase
         $container->get('config')
             ->willReturn([ ModuleConfig::CONFIG_KEY => [] ]);
 
-        $this->assertInstanceOf(
-            Config::class,
+        $this->assertInternalType(
+            'array',
             $factory($container->reveal()),
-            'Factory should return config class'
+            'Factory should return array'
         );
     }
 
@@ -44,9 +44,10 @@ class ModuleConfigFactoryTest extends TestCase
 
         $config = $factory($container->reveal());
 
-        $this->assertTrue(
-            $config->offsetExists('extractor'),
-            'Config should container extractor key'
+        $this->assertArrayHasKey(
+            'extractor',
+            $config,
+            'Config should contain extractor key'
         );
     }
 
@@ -65,7 +66,7 @@ class ModuleConfigFactoryTest extends TestCase
 
         $this->assertCount(
             0,
-            $config->toArray(),
+            $config,
             'Config should be empty'
         );
     }

--- a/test/Unit/Service/AutoWiring/Factory/ResolverServiceFactoryTest.php
+++ b/test/Unit/Service/AutoWiring/Factory/ResolverServiceFactoryTest.php
@@ -28,9 +28,7 @@ class ResolverServiceFactoryTest extends TestCase
         $container = $this->prophesize(ContainerInterface::class);
 
         $container->get(ModuleConfig::class)
-            ->willReturn(
-                new Config([])
-            );
+            ->willReturn([]);
 
         $container->get(ContainerResolver::class)->shouldBeCalled();
         $container->get(PluginManagerResolver::class)->shouldBeCalled();
@@ -55,7 +53,7 @@ class ResolverServiceFactoryTest extends TestCase
 
         $container->get(ModuleConfig::class)
             ->willReturn(
-                new Config(['autowire_resolver' => [ TestResolver::class ]])
+                ['autowire_resolver' => [ TestResolver::class ], ]
             );
 
         $container->get(ContainerResolver::class)->shouldBeCalled();

--- a/test/Unit/Service/Factory/CacheServiceFactoryTest.php
+++ b/test/Unit/Service/Factory/CacheServiceFactoryTest.php
@@ -8,7 +8,6 @@ use Reinfi\DependencyInjection\Config\ModuleConfig;
 use Reinfi\DependencyInjection\Service\CacheService;
 use Reinfi\DependencyInjection\Service\Factory\CacheServiceFactory;
 use Zend\Cache\Storage\Adapter\Memory;
-use Zend\Config\Config;
 
 /**
  * @package Reinfi\DependencyInjection\Unit\Service\Factory
@@ -23,7 +22,7 @@ class CacheServiceFactoryTest extends TestCase
      */
     public function itInstancesCacheService(array $options)
     {
-        $moduleConfig = new Config($options);
+        $moduleConfig = $options;
 
         $container = $this->prophesize(ContainerInterface::class);
 


### PR DESCRIPTION
Performance Optimization.

Always creating a Config object is only needed for coding but is much slower than a simple array structure.