### PR TITLE
Check cache item

### DIFF
--- a/src/Service/AutoWiringService.php
+++ b/src/Service/AutoWiringService.php
@@ -70,7 +70,11 @@ class AutoWiringService
         $cacheKey = $this->buildCacheKey($className);
 
         if ($this->cache->hasItem($cacheKey)) {
-            return $this->cache->getItem($cacheKey);
+            $cachedItem = $this->cache->getItem($cacheKey);
+
+            if (is_array($cachedItem)) {
+                return $cachedItem;
+            }
         }
 
         $injections = $this->resolverService->resolve($className);

--- a/src/Service/InjectionService.php
+++ b/src/Service/InjectionService.php
@@ -70,7 +70,11 @@ class InjectionService
         $cacheKey = $this->buildCacheKey($className);
 
         if ($this->cache->hasItem($cacheKey)) {
-            return $this->cache->getItem($cacheKey);
+            $cachedItem = $this->cache->getItem($cacheKey);
+
+            if (is_array($cachedItem)) {
+                return $cachedItem;
+            }
         }
 
         $injections = array_merge(

--- a/test/Unit/Service/InjectionServiceTest.php
+++ b/test/Unit/Service/InjectionServiceTest.php
@@ -140,6 +140,47 @@ class InjectionServiceTest extends TestCase
     /**
      * @test
      */
+    public function itUsesExtractorWhenCacheItemIsNotAnArray()
+    {
+        $cacheKey = $this->buildCacheKey(Service1::class);
+        $extractor = $this->prophesize(ExtractorInterface::class);
+
+        $injection = $this->prophesize(InjectionInterface::class);
+        $injection->addMethodProphecy(
+            (new MethodProphecy($injection, '__invoke', [Argument::type(ContainerInterface::class)]))
+            ->willReturn(new Service2())
+        );
+
+        $extractor->getConstructorInjections(Service1::class)
+            ->willReturn([]);
+        $extractor->getPropertiesInjections(Service1::class)
+            ->willReturn([
+                             $injection->reveal(),
+                         ]);
+
+        $cache = $this->prophesize(CacheService::class);
+        $cache->hasItem($cacheKey)->willReturn(true)->shouldBeCalled();
+        $cache->getItem($cacheKey)->willReturn(null)->shouldBeCalled();
+        $cache->setItem($cacheKey, Argument::type('array'))->willReturn(true);
+
+        $service = new InjectionService(
+            $extractor->reveal(),
+            $cache->reveal()
+        );
+
+        $container = $this->prophesize(ContainerInterface::class);
+
+        $injections = $service->resolveConstructorInjection(
+            $container->reveal(),
+            Service1::class
+        );
+
+        $this->assertCount(1, $injections);
+    }
+
+    /**
+     * @test
+     */
     public function itReturnsFalseWhenNoInjectionsAvaible()
     {
         $cacheKey = $this->buildCacheKey(Service2::class);


### PR DESCRIPTION
There was a problem that the cache does not return an array. 

This causes a fatal error which is not needed, so added a check for type array.