### PR TITLE
Strict return type

### DIFF
--- a/src/Factory/AutoWiringFactory.php
+++ b/src/Factory/AutoWiringFactory.php
@@ -28,7 +28,7 @@ final class AutoWiringFactory extends AbstractFactory
             $requestedName
         );
 
-        if (count($injections) === 0) {
+        if ($injections === null) {
             return new $requestedName;
         }
 

--- a/src/Factory/AutoWiringFactory.php
+++ b/src/Factory/AutoWiringFactory.php
@@ -28,7 +28,7 @@ final class AutoWiringFactory extends AbstractFactory
             $requestedName
         );
 
-        if ($injections === false) {
+        if (count($injections) === 0) {
             return new $requestedName;
         }
 

--- a/src/Service/AutoWiringService.php
+++ b/src/Service/AutoWiringService.php
@@ -43,16 +43,16 @@ class AutoWiringService
      * @param ContainerInterface $container
      * @param string             $className
      *
-     * @return array|bool
+     * @return array
      */
     public function resolveConstructorInjection(
         ContainerInterface $container,
         string $className
-    ) {
+    ): array {
         $injections = $this->getInjections($className);
 
         if (count($injections) === 0) {
-            return false;
+            return [];
         }
 
         foreach ($injections as $index => $injection) {

--- a/src/Service/AutoWiringService.php
+++ b/src/Service/AutoWiringService.php
@@ -43,7 +43,7 @@ class AutoWiringService
      * @param ContainerInterface $container
      * @param string             $className
      *
-     * @return array
+     * @return InjectionInterface[]
      */
     public function resolveConstructorInjection(
         ContainerInterface $container,

--- a/src/Service/AutoWiringService.php
+++ b/src/Service/AutoWiringService.php
@@ -43,16 +43,16 @@ class AutoWiringService
      * @param ContainerInterface $container
      * @param string             $className
      *
-     * @return InjectionInterface[]
+     * @return InjectionInterface[]|null
      */
     public function resolveConstructorInjection(
         ContainerInterface $container,
         string $className
-    ): array {
+    ): ?array {
         $injections = $this->getInjections($className);
 
         if (count($injections) === 0) {
-            return [];
+            return null;
         }
 
         foreach ($injections as $index => $injection) {

--- a/test/Unit/Factory/AutoWiringFactoryTest.php
+++ b/test/Unit/Factory/AutoWiringFactoryTest.php
@@ -117,7 +117,7 @@ class AutoWiringFactoryTest extends TestCase
         $service->resolveConstructorInjection(
             Argument::type(ContainerInterface::class),
             Service2::class
-        )->willReturn([]);
+        )->willReturn(null);
 
         $container = $this->prophesize(ServiceLocatorInterface::class);
         $container->get(AutoWiringService::class)

--- a/test/Unit/Factory/AutoWiringFactoryTest.php
+++ b/test/Unit/Factory/AutoWiringFactoryTest.php
@@ -117,7 +117,7 @@ class AutoWiringFactoryTest extends TestCase
         $service->resolveConstructorInjection(
             Argument::type(ContainerInterface::class),
             Service2::class
-        )->willReturn(false);
+        )->willReturn([]);
 
         $container = $this->prophesize(ServiceLocatorInterface::class);
         $container->get(AutoWiringService::class)

--- a/test/Unit/Service/AutoWiringServiceTest.php
+++ b/test/Unit/Service/AutoWiringServiceTest.php
@@ -158,6 +158,10 @@ class AutoWiringServiceTest extends TestCase
             Service2::class
         );
 
-        $this->assertFalse($injections);
+        $this->assertCount(
+            0,
+            $injections,
+            'Array should be empty if service has no injections'
+        );
     }
 }

--- a/test/Unit/Service/AutoWiringServiceTest.php
+++ b/test/Unit/Service/AutoWiringServiceTest.php
@@ -158,10 +158,9 @@ class AutoWiringServiceTest extends TestCase
             Service2::class
         );
 
-        $this->assertCount(
-            0,
+        $this->assertNull(
             $injections,
-            'Array should be empty if service has no injections'
+            'Return value should be null if service has no injections'
         );
     }
 }


### PR DESCRIPTION
Do not use combined return value array and bool for autowiring service. Instead return null or array if no injection is found.