### PR TITLE
Service with factory as a closure throws an error when running cache warmup 

### DIFF
--- a/src/Traits/WarmupTrait.php
+++ b/src/Traits/WarmupTrait.php
@@ -33,6 +33,9 @@ trait WarmupTrait
                 $factoryClass,
                 $className
             ) use ($extractor, $resolverService, $cache) {
+                if (! is_string($factoryClass)) {
+                    return;
+                }
                 $injections = $this->handleService(
                     $className,
                     $factoryClass,

--- a/test/resources/config.php
+++ b/test/resources/config.php
@@ -1,5 +1,7 @@
 <?php
 
+use Zend\ServiceManager\ServiceLocatorInterface;
+
 return [
     'service_manager' => [
         'factories' => [
@@ -10,6 +12,7 @@ return [
             \Reinfi\DependencyInjection\Service\ServiceContainer::class                           => \Reinfi\DependencyInjection\Factory\AutoWiringFactory::class,
             \Reinfi\DependencyInjection\Service\ServiceBuildInTypeWithDefault::class              => \Reinfi\DependencyInjection\Factory\AutoWiringFactory::class,
             \Reinfi\DependencyInjection\Service\ServiceBuildInTypeWithDefaultUsingConstant::class => \Reinfi\DependencyInjection\Factory\AutoWiringFactory::class,
+            'service_with_closure_as_factory'                                                     => function (ServiceLocatorInterface $locator) { return new \stdClass();},
         ],
     ],
     'test'            => [


### PR DESCRIPTION
When one of the services factories are implemented as a closure, the warmup cache command will fail with error:

`
 TypeError
 Argument 2 passed to Reinfi\DependencyInjection\Controller\CacheWarmupController::handleService() must be of the type string, object given, called in /app/vendor/reinfi/zf-dependency-injection/src/Traits/WarmupTrait.php on line 43
`

Test added