### PR TITLE
Make use of the `$options` parameter

### DIFF
--- a/src/Factory/AutoWiringFactory.php
+++ b/src/Factory/AutoWiringFactory.php
@@ -25,9 +25,10 @@ final class AutoWiringFactory extends AbstractFactory
 
         $injections = $autoWiringService->resolveConstructorInjection(
             $container,
-            $requestedName
+            $requestedName,
+            $options
         );
-
+        
         if ($injections === null) {
             return new $requestedName;
         }
@@ -45,7 +46,7 @@ final class AutoWiringFactory extends AbstractFactory
         if ($container instanceof AbstractPluginManager) {
             $container = $container->getServiceLocator();
         }
-
+        
         return $container->get(AutoWiringService::class);
     }
 }

--- a/src/Service/AutoWiring/LazyResolverService.php
+++ b/src/Service/AutoWiring/LazyResolverService.php
@@ -34,12 +34,12 @@ class LazyResolverService implements ResolverServiceInterface
     /**
      * @inheritdoc
      */
-    public function resolve(string $className): array
+    public function resolve(string $className, ?array $options = null): array
     {
         if (!$this->resolverService instanceof ResolverServiceInterface) {
             $this->resolverService = $this->container->get(ResolverService::class);
         }
 
-        return $this->resolverService->resolve($className);
+        return $this->resolverService->resolve($className, $options);
     }
 }

--- a/src/Service/AutoWiring/ResolverService.php
+++ b/src/Service/AutoWiring/ResolverService.php
@@ -30,11 +30,12 @@ class ResolverService implements ResolverServiceInterface
     }
 
     /**
-     * @param string $className
+     * @param string     $className
+     * @param null|array $options
      *
      * @return InjectionInterface[]
      */
-    public function resolve(string $className): array
+    public function resolve(string $className, ?array $options = null): array
     {
         $reflClass = new ReflectionClass($className);
 
@@ -44,7 +45,12 @@ class ResolverService implements ResolverServiceInterface
             return [];
         }
 
-        $parameters = $constructor->getParameters();
+        $parameters = array_filter(
+            $constructor->getParameters(),
+            function (\ReflectionParameter $parameter) use ($options) {
+                return !array_key_exists($parameter->getName(), $options ?? []);
+            }
+        );
 
         return array_map([ $this, 'resolveParameter' ], $parameters);
     }

--- a/src/Service/AutoWiring/ResolverService.php
+++ b/src/Service/AutoWiring/ResolverService.php
@@ -45,6 +45,7 @@ class ResolverService implements ResolverServiceInterface
             return [];
         }
 
+	// Filter out constructor parameters that are already provided inside the $options array
         $parameters = array_filter(
             $constructor->getParameters(),
             function (\ReflectionParameter $parameter) use ($options) {

--- a/src/Service/AutoWiring/ResolverServiceInterface.php
+++ b/src/Service/AutoWiring/ResolverServiceInterface.php
@@ -12,9 +12,10 @@ use Reinfi\DependencyInjection\Injection\InjectionInterface;
 interface ResolverServiceInterface
 {
     /**
-     * @param string $className
+     * @param string     $className
+     * @param null|array $options
      *
      * @return InjectionInterface[]
      */
-    public function resolve(string $className): array;
+    public function resolve(string $className, ?array $options = null): array;
 }

--- a/src/Service/AutoWiringService.php
+++ b/src/Service/AutoWiringService.php
@@ -53,7 +53,7 @@ class AutoWiringService
     ): ?array {
         $injections = $this->getInjections($className, $options);
 
-        if (empty($injections) && $options === null) {
+        if (count($injections) === 0 && $options === null) {
             return null;
         }
 

--- a/src/Service/AutoWiringService.php
+++ b/src/Service/AutoWiringService.php
@@ -42,16 +42,18 @@ class AutoWiringService
     /**
      * @param ContainerInterface $container
      * @param string             $className
+     * @param null|array         $options
      *
      * @return InjectionInterface[]|null
      */
     public function resolveConstructorInjection(
         ContainerInterface $container,
-        string $className
+        string $className,
+        ?array $options = null
     ): ?array {
-        $injections = $this->getInjections($className);
+        $injections = $this->getInjections($className, $options);
 
-        if (count($injections) === 0) {
+        if (empty($injections) && $options === null) {
             return null;
         }
 
@@ -59,7 +61,7 @@ class AutoWiringService
             $injections[$index] = $injection($container);
         }
 
-        return $injections;
+        return array_merge($injections, $options ?? []);
     }
 
     /**
@@ -67,7 +69,7 @@ class AutoWiringService
      *
      * @return InjectionInterface[]
      */
-    private function getInjections(string $className): array
+    private function getInjections(string $className, ?array $options = null): array
     {
         $cacheKey = $this->buildCacheKey($className);
 
@@ -79,7 +81,7 @@ class AutoWiringService
             }
         }
 
-        $injections = $this->resolverService->resolve($className);
+        $injections = $this->resolverService->resolve($className, $options);
         $this->cache->setItem($cacheKey, $injections);
 
         return $injections;

--- a/test/Unit/Factory/AutoWiringFactoryTest.php
+++ b/test/Unit/Factory/AutoWiringFactoryTest.php
@@ -27,7 +27,8 @@ class AutoWiringFactoryTest extends TestCase
         $service = $this->prophesize(AutoWiringService::class);
         $service->resolveConstructorInjection(
             Argument::type(ContainerInterface::class),
-            Service1::class
+            Service1::class,
+            null
         )->willReturn([new Service2(), new Service3()]);
 
         $container = $this->prophesize(ServiceLocatorInterface::class);
@@ -51,12 +52,40 @@ class AutoWiringFactoryTest extends TestCase
     /**
      * @test
      */
+    public function itCreatesServiceWithInjectionsWithOptions()
+    {
+        $options = ['foo' => 'bar'];
+        $service = $this->prophesize(AutoWiringService::class);
+        $service->resolveConstructorInjection(
+            Argument::type(ContainerInterface::class),
+            Service1::class,
+            $options
+        )->willReturn([new Service2(), new Service3()]);
+
+        $container = $this->prophesize(ServiceLocatorInterface::class);
+        $container->get(AutoWiringService::class)
+            ->willReturn($service->reveal());
+
+        $factory = new AutoWiringFactory();
+
+        $instance = $factory($container->reveal(), Service1::class, $options);
+
+        $this->assertInstanceOf(
+            Service1::class,
+            $instance
+        );
+    }
+
+    /**
+     * @test
+     */
     public function itCreatesServiceFromCanonicalName()
     {
         $service = $this->prophesize(AutoWiringService::class);
         $service->resolveConstructorInjection(
             Argument::type(ContainerInterface::class),
-            Service1::class
+            Service1::class,
+            null
         )->willReturn([new Service2(), new Service3()]);
 
         $container = $this->prophesize(ServiceLocatorInterface::class);
@@ -84,7 +113,8 @@ class AutoWiringFactoryTest extends TestCase
         $service = $this->prophesize(AutoWiringService::class);
         $service->resolveConstructorInjection(
             Argument::type(ContainerInterface::class),
-            Service1::class
+            Service1::class,
+            null
         )->willReturn([new Service2(), new Service3()]);
 
         $container = $this->prophesize(ServiceLocatorInterface::class);
@@ -116,7 +146,8 @@ class AutoWiringFactoryTest extends TestCase
         $service = $this->prophesize(AutoWiringService::class);
         $service->resolveConstructorInjection(
             Argument::type(ContainerInterface::class),
-            Service2::class
+            Service2::class,
+            null
         )->willReturn(null);
 
         $container = $this->prophesize(ServiceLocatorInterface::class);

--- a/test/Unit/Service/AutoWiring/LazyResolverServiceTest.php
+++ b/test/Unit/Service/AutoWiring/LazyResolverServiceTest.php
@@ -21,7 +21,7 @@ class LazyResolverServiceTest extends TestCase
     public function itResolvesResolverServiceLazy()
     {
         $resolverService = $this->prophesize(ResolverServiceInterface::class);
-        $resolverService->resolve('test')
+        $resolverService->resolve('test', null)
             ->willReturn([]);
 
         $container = $this->prophesize(ContainerInterface::class);
@@ -37,12 +37,33 @@ class LazyResolverServiceTest extends TestCase
     /**
      * @test
      */
+    public function itResolvesResolverServiceLazyWithOptions()
+    {
+        $options = ['foo' => 'bar'];
+
+        $resolverService = $this->prophesize(ResolverServiceInterface::class);
+        $resolverService->resolve('test', $options)
+                        ->willReturn([]);
+
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->get(ResolverService::class)
+                  ->willReturn($resolverService->reveal())
+                  ->shouldBeCalled();
+
+        $service = new LazyResolverService($container->reveal());
+
+        $service->resolve('test', $options);
+    }
+
+    /**
+     * @test
+     */
     public function itResolvesResolverServiceOnlyOnce()
     {
         $resolverService = $this->prophesize(ResolverServiceInterface::class);
-        $resolverService->resolve('test')
+        $resolverService->resolve('test', null)
             ->willReturn([]);
-        $resolverService->resolve('test2')
+        $resolverService->resolve('test2', null)
             ->willReturn([]);
 
         $container = $this->prophesize(ContainerInterface::class);


### PR DESCRIPTION
Use die `$options` parameter to allow the manual injection of arguments when using `ServiceManager::build`.