### PR TITLE
Use numeric index for $options parameters

### DIFF
--- a/src/Service/AutoWiringService.php
+++ b/src/Service/AutoWiringService.php
@@ -61,7 +61,7 @@ class AutoWiringService
             $injections[$index] = $injection($container);
         }
 
-        return array_merge($injections, $options ?? []);
+        return $injections;
     }
 
     /**
@@ -73,7 +73,7 @@ class AutoWiringService
     {
         $cacheKey = $this->buildCacheKey($className);
 
-        if ($this->cache->hasItem($cacheKey)) {
+        if ($options === null && $this->cache->hasItem($cacheKey)) {
             $cachedItem = $this->cache->getItem($cacheKey);
 
             if (is_array($cachedItem)) {

--- a/test/Service/Service1.php
+++ b/test/Service/Service1.php
@@ -10,10 +10,12 @@ class Service1
     /**
      * @param Service2 $service2
      * @param Service3 $service3
+     * @param string   $foo
      */
     public function __construct(
         Service2 $service2,
-        Service3 $service3
+        Service3 $service3,
+        string $foo = ''
     ) {
     }
 }

--- a/test/Unit/Service/AutoWiring/ResolverServiceTest.php
+++ b/test/Unit/Service/AutoWiring/ResolverServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace Reinfi\DependencyInjection\Unit\Service\AutoWiring;
 
+use Interop\Container\ContainerInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Reinfi\DependencyInjection\Exception\AutoWiringNotPossibleException;
@@ -34,9 +35,34 @@ class ResolverServiceTest extends TestCase
 
         $injections = $service->resolve(Service1::class);
 
-        $this->assertCount(2, $injections);
+        $this->assertCount(3, $injections);
         $this->assertContainsOnlyInstancesOf(
             InjectionInterface::class, $injections
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itResolvesConstructorArgumentsWithOptionsParameter()
+    {
+        $resolver = $this->prophesize(ResolverInterface::class);
+        $resolver->resolve(Argument::type(\ReflectionParameter::class))
+            ->willReturn(
+                new AutoWiring(Service2::class)
+            );
+
+        $service = new ResolverService([ $resolver->reveal() ]);
+
+        $injections = $service->resolve(Service1::class, ['foo' => 'bar']);
+
+        $this->assertCount(3, $injections);
+        $this->assertContainsOnlyInstancesOf(
+            InjectionInterface::class, $injections
+        );
+        $this->assertSame(
+            'bar',
+            $injections[2]($this->prophesize(ContainerInterface::class)->reveal())
         );
     }
 


### PR DESCRIPTION
The injection parameters provided with the `$options` array must also have the correct numeric index according to their position inside the constructor.