### PR TITLE
Fix options caching

### DIFF
--- a/src/Service/AutoWiringService.php
+++ b/src/Service/AutoWiringService.php
@@ -82,7 +82,10 @@ class AutoWiringService
         }
 
         $injections = $this->resolverService->resolve($className, $options);
-        $this->cache->setItem($cacheKey, $injections);
+
+        if ($options === null) {
+            $this->cache->setItem($cacheKey, $injections);
+        }
 
         return $injections;
     }

--- a/test/Unit/Service/AutoWiringServiceTest.php
+++ b/test/Unit/Service/AutoWiringServiceTest.php
@@ -173,7 +173,7 @@ class AutoWiringServiceTest extends TestCase
             ]);
 
         $cache = $this->prophesize(CacheService::class);
-        $cache->setItem($cacheKey, Argument::type('array'))->willReturn(true);
+        $cache->setItem($cacheKey, Argument::type('array'))->shouldNotBeCalled();
         $cache->hasItem($cacheKey)->shouldNotBeCalled();
         $cache->getItem($cacheKey)->shouldNotBeCalled();
 


### PR DESCRIPTION
Don't cache injections when using `\Zend\ServiceManager\ServiceLocatorInterface::build` with `$options`, because serialization is not always possible for those values.