### PR TITLE
Add 'entityManager' as possible annotation value

### DIFF
--- a/src/Annotation/InjectDoctrineRepository.php
+++ b/src/Annotation/InjectDoctrineRepository.php
@@ -30,8 +30,8 @@ final class InjectDoctrineRepository extends AbstractAnnotation
     public function __construct(array $values)
     {
         if (!isset($values['value'])) {
-            if (isset($values['em'])) {
-                $this->entityManager = $values['em'];
+            if (isset($values['em']) || isset($values['entityManager'])) {
+                $this->entityManager = $values['entityManager'] ?? $values['em'];
             }
 
             $this->entity = $values['entity'];

--- a/test/Unit/Annotation/InjectDoctrineRepositoryTest.php
+++ b/test/Unit/Annotation/InjectDoctrineRepositoryTest.php
@@ -144,6 +144,14 @@ class InjectDoctrineRepositoryTest extends TestCase
                 'doctrine.entityManager',
                 EntityRepository::class,
             ],
+            [
+                [
+                    'entity'        => EntityRepository::class,
+                    'entityManager' => 'doctrine.entityManager',
+                ],
+                'doctrine.entityManager',
+                EntityRepository::class,
+            ],
         ];
     }
 }


### PR DESCRIPTION
Reason for this change is that the IDE parses the private attributes of the annotation and provides those as autocomplete. So this is simply a convenience change.

![image](https://user-images.githubusercontent.com/883543/60889435-4a121980-a259-11e9-8746-2f2380c14d46.png)
