### PR TITLE
Fix/psr 4 autoload violation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
       "Reinfi\\DependencyInjection\\Test\\": "test/"
     }
   },
-  "suggests": {
+  "suggest": {
     "doctrine/annotations": "To use annotation injections",
     "zendframework/zend-mvc-console": "To use console warmup command route",
     "symfony/console": "To use console warmup command script",

--- a/composer.json
+++ b/composer.json
@@ -27,10 +27,12 @@
   },
   "autoload": {
     "psr-4": {
-      "Reinfi\\DependencyInjection\\": [
-        "src/",
-        "test/"
-      ]
+      "Reinfi\\DependencyInjection\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Reinfi\\DependencyInjection\\Test\\": "test/"
     }
   },
   "suggests": {

--- a/test/Integration/AbstractIntegrationTest.php
+++ b/test/Integration/AbstractIntegrationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Integration;
+namespace Reinfi\DependencyInjection\Test\Integration;
 
 use PHPUnit\Framework\TestCase;
 use Reinfi\DependencyInjection\Annotation\Inject;
@@ -12,7 +12,7 @@ use Zend\ServiceManager\ServiceManager;
 use Zend\Stdlib\ArrayUtils;
 
 /**
- * @package Reinfi\DependencyInjection\Integration
+ * @package Reinfi\DependencyInjection\Test\Integration
  */
 abstract class AbstractIntegrationTest extends TestCase
 {

--- a/test/Integration/Command/CacheWarmupCommandTest.php
+++ b/test/Integration/Command/CacheWarmupCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Integration\Command;
+namespace Reinfi\DependencyInjection\Test\Integration\Command;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * @package Reinfi\DependencyInjection\Integration\Command
+ * @package Reinfi\DependencyInjection\Test\Integration\Command
  *
  * @group integration
  */

--- a/test/Integration/Controller/CacheWarmupControllerTest.php
+++ b/test/Integration/Controller/CacheWarmupControllerTest.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Integration\Controller;
+namespace Reinfi\DependencyInjection\Test\Integration\Controller;
 
 use Prophecy\Argument;
 use Reinfi\DependencyInjection\Controller\CacheWarmupController;
-use Reinfi\DependencyInjection\Integration\AbstractIntegrationTest;
+use Reinfi\DependencyInjection\Test\Integration\AbstractIntegrationTest;
 use Reinfi\DependencyInjection\Service\AutoWiring\ResolverService;
 use Reinfi\DependencyInjection\Service\Extractor\ExtractorInterface;
 use Zend\Cache\Storage\StorageInterface;
 use Zend\Console\Adapter\AdapterInterface;
 
 /**
- * @package Reinfi\DependencyInjection\Integration\Controller
+ * @package Reinfi\DependencyInjection\Test\Integration\Controller
  *
  * @group integration
  */

--- a/test/Integration/Factory/AutoWiringFactoryTest.php
+++ b/test/Integration/Factory/AutoWiringFactoryTest.php
@@ -1,21 +1,21 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Integration\Factory;
+namespace Reinfi\DependencyInjection\Test\Integration\Factory;
 
 use Reinfi\DependencyInjection\Factory\AutoWiringFactory;
-use Reinfi\DependencyInjection\Integration\AbstractIntegrationTest;
-use Reinfi\DependencyInjection\Service\PluginService;
-use Reinfi\DependencyInjection\Service\Service1;
-use Reinfi\DependencyInjection\Service\Service2;
-use Reinfi\DependencyInjection\Service\Service3;
-use Reinfi\DependencyInjection\Service\ServiceBuildInTypeWithDefault;
-use Reinfi\DependencyInjection\Service\ServiceBuildInTypeWithDefaultUsingConstant;
-use Reinfi\DependencyInjection\Service\ServiceContainer;
+use Reinfi\DependencyInjection\Test\Integration\AbstractIntegrationTest;
+use Reinfi\DependencyInjection\Test\Service\PluginService;
+use Reinfi\DependencyInjection\Test\Service\Service1;
+use Reinfi\DependencyInjection\Test\Service\Service2;
+use Reinfi\DependencyInjection\Test\Service\Service3;
+use Reinfi\DependencyInjection\Test\Service\ServiceBuildInTypeWithDefault;
+use Reinfi\DependencyInjection\Test\Service\ServiceBuildInTypeWithDefaultUsingConstant;
+use Reinfi\DependencyInjection\Test\Service\ServiceContainer;
 use Zend\ServiceManager\AbstractPluginManager;
 use Zend\ServiceManager\Exception\InvalidServiceException;
 
 /**
- * @package Reinfi\DependencyInjection\Integration\Factory
+ * @package Reinfi\DependencyInjection\Test\Integration\Factory
  *
  * @group integration
  */

--- a/test/Integration/Factory/InjectionFactoryTest.php
+++ b/test/Integration/Factory/InjectionFactoryTest.php
@@ -1,21 +1,21 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Integration\Factory;
+namespace Reinfi\DependencyInjection\Test\Integration\Factory;
 
 use Reinfi\DependencyInjection\Factory\InjectionFactory;
-use Reinfi\DependencyInjection\Integration\AbstractIntegrationTest;
+use Reinfi\DependencyInjection\Test\Integration\AbstractIntegrationTest;
 use Reinfi\DependencyInjection\Service\Extractor\YamlExtractor;
-use Reinfi\DependencyInjection\Service\PluginService;
-use Reinfi\DependencyInjection\Service\Service1;
-use Reinfi\DependencyInjection\Service\Service3;
-use Reinfi\DependencyInjection\Service\ServiceAnnotation;
-use Reinfi\DependencyInjection\Service\ServiceAnnotationConstructor;
+use Reinfi\DependencyInjection\Test\Service\PluginService;
+use Reinfi\DependencyInjection\Test\Service\Service1;
+use Reinfi\DependencyInjection\Test\Service\Service3;
+use Reinfi\DependencyInjection\Test\Service\ServiceAnnotation;
+use Reinfi\DependencyInjection\Test\Service\ServiceAnnotationConstructor;
 use Zend\ServiceManager\AbstractPluginManager;
 use Zend\ServiceManager\Exception\InvalidServiceException;
 use Zend\Stdlib\ArrayUtils;
 
 /**
- * @package Reinfi\DependencyInjection\Integration\Factory
+ * @package Reinfi\DependencyInjection\Test\Integration\Factory
  *
  * @group integration
  */

--- a/test/Service/BadInjectionClass.php
+++ b/test/Service/BadInjectionClass.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Service;
+namespace Reinfi\DependencyInjection\Test\Service;
 
 /**
  * Does not implements InjectionInterface.
  *
- * @package Reinfi\DependencyInjection\Service
+ * @package Reinfi\DependencyInjection\Test\Service
  */
 class BadInjectionClass
 {

--- a/test/Service/Factory/Service3Factory.php
+++ b/test/Service/Factory/Service3Factory.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Service\Factory;
+namespace Reinfi\DependencyInjection\Test\Service\Factory;
 
 use Interop\Container\ContainerInterface;
-use Reinfi\DependencyInjection\Service\Service3;
+use Reinfi\DependencyInjection\Test\Service\Service3;
 
 /**
- * @package Reinfi\DependencyInjection\Service\Factory
+ * @package Reinfi\DependencyInjection\Test\Service\Factory
  */
 class Service3Factory
 {

--- a/test/Service/PluginService.php
+++ b/test/Service/PluginService.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Service;
+namespace Reinfi\DependencyInjection\Test\Service;
 
 use Reinfi\DependencyInjection\Annotation\InjectParent;
 
 /**
- * @package Reinfi\DependencyInjection\Service
+ * @package Reinfi\DependencyInjection\Test\Service
  */
 class PluginService
 {
     /**
-     * @InjectParent("Reinfi\DependencyInjection\Service\Service2")
+     * @InjectParent("Reinfi\DependencyInjection\Test\Service\Service2")
      *
      * @var Service2
      */

--- a/test/Service/Resolver/TestResolver.php
+++ b/test/Service/Resolver/TestResolver.php
@@ -1,19 +1,20 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Service\Resolver;
+namespace Reinfi\DependencyInjection\Test\Service\Resolver;
 
 use ReflectionParameter;
+use Reinfi\DependencyInjection\Injection\InjectionInterface;
 use Reinfi\DependencyInjection\Service\AutoWiring\Resolver\ResolverInterface;
 
 /**
- * @package Reinfi\DependencyInjection\Service\Resolver
+ * @package Reinfi\DependencyInjection\Test\Service\Resolver
  */
 class TestResolver implements ResolverInterface
 {
     /**
      * @inheritDoc
      */
-    public function resolve(ReflectionParameter $parameter)
+    public function resolve(ReflectionParameter $parameter): ?InjectionInterface
     {
         return null;
     }

--- a/test/Service/Service1.php
+++ b/test/Service/Service1.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Service;
+namespace Reinfi\DependencyInjection\Test\Service;
 
 /**
- * @package Reinfi\DependencyInjection\Service
+ * @package Reinfi\DependencyInjection\Test\Service
  */
 class Service1
 {

--- a/test/Service/Service2.php
+++ b/test/Service/Service2.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Service;
+namespace Reinfi\DependencyInjection\Test\Service;
 
 /**
- * @package Reinfi\DependencyInjection\Service
+ * @package Reinfi\DependencyInjection\Test\Service
  */
 class Service2
 {

--- a/test/Service/Service3.php
+++ b/test/Service/Service3.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Service;
+namespace Reinfi\DependencyInjection\Test\Service;
 
 /**
- * @package Reinfi\DependencyInjection\Service
+ * @package Reinfi\DependencyInjection\Test\Service
  */
 class Service3
 {

--- a/test/Service/ServiceAnnotation.php
+++ b/test/Service/ServiceAnnotation.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Service;
+namespace Reinfi\DependencyInjection\Test\Service;
 
 use Reinfi\DependencyInjection\Annotation\Inject;
 use Reinfi\DependencyInjection\Annotation\InjectConfig;
 
 /**
- * @package Reinfi\DependencyInjection\Service
+ * @package Reinfi\DependencyInjection\Test\Service
  */
 class ServiceAnnotation
 {
     /**
-     * @Inject("Reinfi\DependencyInjection\Service\Service2")
+     * @Inject("Reinfi\DependencyInjection\Test\Service\Service2")
      *
      * @var Service2
      */

--- a/test/Service/ServiceAnnotationConstructor.php
+++ b/test/Service/ServiceAnnotationConstructor.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Service;
+namespace Reinfi\DependencyInjection\Test\Service;
 
 use Reinfi\DependencyInjection\Annotation\Inject;
 use Reinfi\DependencyInjection\Annotation\InjectConfig;
 use Reinfi\DependencyInjection\Annotation\InjectConstant;
 
 /**
- * @package Reinfi\DependencyInjection\Service
+ * @package Reinfi\DependencyInjection\Test\Service
  */
 class ServiceAnnotationConstructor
 {
@@ -27,9 +27,9 @@ class ServiceAnnotationConstructor
     protected $constant;
 
     /**
-     * @Inject("Reinfi\DependencyInjection\Service\Service2")
+     * @Inject("Reinfi\DependencyInjection\Test\Service\Service2")
      * @InjectConfig("test.value")
-     * @InjectConstant("Reinfi\DependencyInjection\Service\Service2::CONSTANT")
+     * @InjectConstant("Reinfi\DependencyInjection\Test\Service\Service2::CONSTANT")
      *
      * @param Service2 $service2
      * @param int      $value

--- a/test/Service/ServiceBuildInType.php
+++ b/test/Service/ServiceBuildInType.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Service;
+namespace Reinfi\DependencyInjection\Test\Service;
 
 /**
- * @package Reinfi\DependencyInjection\Service
+ * @package Reinfi\DependencyInjection\Test\Service
  */
 class ServiceBuildInType
 {

--- a/test/Service/ServiceBuildInTypeWithDefault.php
+++ b/test/Service/ServiceBuildInTypeWithDefault.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Service;
+namespace Reinfi\DependencyInjection\Test\Service;
 
 /**
- * @package Reinfi\DependencyInjection\Service
+ * @package Reinfi\DependencyInjection\Test\Service
  */
 class ServiceBuildInTypeWithDefault
 {

--- a/test/Service/ServiceBuildInTypeWithDefaultUsingConstant.php
+++ b/test/Service/ServiceBuildInTypeWithDefaultUsingConstant.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Service;
+namespace Reinfi\DependencyInjection\Test\Service;
 
 /**
- * @package Reinfi\DependencyInjection\Service
+ * @package Reinfi\DependencyInjection\Test\Service
  */
 class ServiceBuildInTypeWithDefaultUsingConstant
 {

--- a/test/Service/ServiceContainer.php
+++ b/test/Service/ServiceContainer.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Service;
+namespace Reinfi\DependencyInjection\Test\Service;
 
 use Psr\Container\ContainerInterface;
 
 /**
- * @package Reinfi\DependencyInjection\Service
+ * @package Reinfi\DependencyInjection\Test\Service
  */
 class ServiceContainer
 {

--- a/test/Service/ServiceNoTypeHint.php
+++ b/test/Service/ServiceNoTypeHint.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Service;
+namespace Reinfi\DependencyInjection\Test\Service;
 
 /**
- * @package Reinfi\DependencyInjection\Service
+ * @package Reinfi\DependencyInjection\Test\Service
  */
 class ServiceNoTypeHint
 {

--- a/test/Unit/AbstractFactory/Config/InjectConfigAbstractFactoryTest.php
+++ b/test/Unit/AbstractFactory/Config/InjectConfigAbstractFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\AbstractFactory\Config;
+namespace Reinfi\DependencyInjection\Test\Unit\AbstractFactory\Config;
 
 use PHPUnit\Framework\TestCase;
 use Reinfi\DependencyInjection\AbstractFactory\Config\InjectConfigAbstractFactory;
@@ -8,7 +8,7 @@ use Reinfi\DependencyInjection\Service\ConfigService;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\AbstractFactory\Config
+ * @package Reinfi\DependencyInjection\Test\Unit\AbstractFactory\Config
  */
 class InjectConfigAbstractFactoryTest extends TestCase
 {

--- a/test/Unit/Annotation/InjectConfigTest.php
+++ b/test/Unit/Annotation/InjectConfigTest.php
@@ -1,16 +1,15 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Annotation;
+namespace Reinfi\DependencyInjection\Test\Unit\Annotation;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Reinfi\DependencyInjection\Annotation\InjectConfig;
 use Reinfi\DependencyInjection\Service\ConfigService;
-use Reinfi\DependencyInjection\Service\InjectionService;
 use Zend\ServiceManager\AbstractPluginManager;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Annotation
+ * @package Reinfi\DependencyInjection\Test\Unit\Annotation
  */
 class InjectConfigTest extends TestCase
 {

--- a/test/Unit/Annotation/InjectConstantTest.php
+++ b/test/Unit/Annotation/InjectConstantTest.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Annotation;
+namespace Reinfi\DependencyInjection\Test\Unit\Annotation;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Reinfi\DependencyInjection\Annotation\InjectConstant;
 use Reinfi\DependencyInjection\Service\InjectionService;
-use Reinfi\DependencyInjection\Service\Service2;
+use Reinfi\DependencyInjection\Test\Service\Service2;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Annotation
+ * @package Reinfi\DependencyInjection\Test\Unit\Annotation
  */
 class InjectConstantTest extends TestCase
 {

--- a/test/Unit/Annotation/InjectContainerTest.php
+++ b/test/Unit/Annotation/InjectContainerTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Annotation;
+namespace Reinfi\DependencyInjection\Test\Unit\Annotation;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Reinfi\DependencyInjection\Annotation\InjectContainer;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Annotation
+ * @package Reinfi\DependencyInjection\Test\Unit\Annotation
  */
 class InjectContainerTest extends TestCase
 {

--- a/test/Unit/Annotation/InjectControllerPluginTest.php
+++ b/test/Unit/Annotation/InjectControllerPluginTest.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Annotation;
+namespace Reinfi\DependencyInjection\Test\Unit\Annotation;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Reinfi\DependencyInjection\Annotation\InjectControllerPlugin;
-use Reinfi\DependencyInjection\Service\Service1;
+use Reinfi\DependencyInjection\Test\Service\Service1;
 use Zend\ServiceManager\AbstractPluginManager;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Annotation
+ * @package Reinfi\DependencyInjection\Test\Unit\Annotation
  */
 class InjectControllerPluginTest extends TestCase
 {

--- a/test/Unit/Annotation/InjectDoctrineRepositoryTest.php
+++ b/test/Unit/Annotation/InjectDoctrineRepositoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Annotation;
+namespace Reinfi\DependencyInjection\Test\Unit\Annotation;
 
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityRepository;
@@ -10,7 +10,7 @@ use Reinfi\DependencyInjection\Annotation\InjectDoctrineRepository;
 use Zend\ServiceManager\AbstractPluginManager;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Annotation
+ * @package Reinfi\DependencyInjection\Test\Unit\Annotation
  */
 class InjectDoctrineRepositoryTest extends TestCase
 {

--- a/test/Unit/Annotation/InjectFilterTest.php
+++ b/test/Unit/Annotation/InjectFilterTest.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Annotation;
+namespace Reinfi\DependencyInjection\Test\Unit\Annotation;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Reinfi\DependencyInjection\Annotation\InjectFilter;
-use Reinfi\DependencyInjection\Service\Service1;
+use Reinfi\DependencyInjection\Test\Service\Service1;
 use Zend\ServiceManager\AbstractPluginManager;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Annotation
+ * @package Reinfi\DependencyInjection\Test\Unit\Annotation
  */
 class InjectFilterTest extends TestCase
 {

--- a/test/Unit/Annotation/InjectFormElementTest.php
+++ b/test/Unit/Annotation/InjectFormElementTest.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Annotation;
+namespace Reinfi\DependencyInjection\Test\Unit\Annotation;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Reinfi\DependencyInjection\Annotation\InjectFormElement;
-use Reinfi\DependencyInjection\Service\Service1;
+use Reinfi\DependencyInjection\Test\Service\Service1;
 use Zend\ServiceManager\AbstractPluginManager;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Annotation
+ * @package Reinfi\DependencyInjection\Test\Unit\Annotation
  */
 class InjectFormElementTest extends TestCase
 {

--- a/test/Unit/Annotation/InjectHydratorTest.php
+++ b/test/Unit/Annotation/InjectHydratorTest.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Annotation;
+namespace Reinfi\DependencyInjection\Test\Unit\Annotation;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Reinfi\DependencyInjection\Annotation\InjectHydrator;
-use Reinfi\DependencyInjection\Service\Service1;
+use Reinfi\DependencyInjection\Test\Service\Service1;
 use Zend\ServiceManager\AbstractPluginManager;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Annotation
+ * @package Reinfi\DependencyInjection\Test\Unit\Annotation
  */
 class InjectHydratorTest extends TestCase
 {

--- a/test/Unit/Annotation/InjectInputFilterTest.php
+++ b/test/Unit/Annotation/InjectInputFilterTest.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Annotation;
+namespace Reinfi\DependencyInjection\Test\Unit\Annotation;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Reinfi\DependencyInjection\Annotation\InjectInputFilter;
-use Reinfi\DependencyInjection\Service\Service1;
+use Reinfi\DependencyInjection\Test\Service\Service1;
 use Zend\ServiceManager\AbstractPluginManager;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Annotation
+ * @package Reinfi\DependencyInjection\Test\Unit\Annotation
  */
 class InjectInputFilterTest extends TestCase
 {

--- a/test/Unit/Annotation/InjectParentTest.php
+++ b/test/Unit/Annotation/InjectParentTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Annotation;
+namespace Reinfi\DependencyInjection\Test\Unit\Annotation;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -9,7 +9,7 @@ use Reinfi\DependencyInjection\Service\InjectionService;
 use Zend\ServiceManager\AbstractPluginManager;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Annotation
+ * @package Reinfi\DependencyInjection\Test\Unit\Annotation
  */
 class InjectParentTest extends TestCase
 {

--- a/test/Unit/Annotation/InjectTest.php
+++ b/test/Unit/Annotation/InjectTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Annotation;
+namespace Reinfi\DependencyInjection\Test\Unit\Annotation;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -8,7 +8,7 @@ use Reinfi\DependencyInjection\Annotation\Inject;
 use Reinfi\DependencyInjection\Service\InjectionService;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Annotation
+ * @package Reinfi\DependencyInjection\Test\Unit\Annotation
  */
 class InjectTest extends TestCase
 {

--- a/test/Unit/Annotation/InjectValidatorTest.php
+++ b/test/Unit/Annotation/InjectValidatorTest.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Annotation;
+namespace Reinfi\DependencyInjection\Test\Unit\Annotation;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Reinfi\DependencyInjection\Annotation\InjectValidator;
-use Reinfi\DependencyInjection\Service\Service1;
+use Reinfi\DependencyInjection\Test\Service\Service1;
 use Zend\ServiceManager\AbstractPluginManager;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Annotation
+ * @package Reinfi\DependencyInjection\Test\Unit\Annotation
  */
 class InjectValidatorTest extends TestCase
 {

--- a/test/Unit/Annotation/InjectViewHelperTest.php
+++ b/test/Unit/Annotation/InjectViewHelperTest.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Annotation;
+namespace Reinfi\DependencyInjection\Test\Unit\Annotation;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Reinfi\DependencyInjection\Annotation\InjectViewHelper;
-use Reinfi\DependencyInjection\Service\Service1;
+use Reinfi\DependencyInjection\Test\Service\Service1;
 use Zend\ServiceManager\AbstractPluginManager;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Annotation
+ * @package Reinfi\DependencyInjection\Test\Unit\Annotation
  */
 class InjectViewHelperTest extends TestCase
 {

--- a/test/Unit/Config/Factory/ModuleConfigFactoryTest.php
+++ b/test/Unit/Config/Factory/ModuleConfigFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Config\Factory;
+namespace Reinfi\DependencyInjection\Test\Unit\Config\Factory;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -8,7 +8,7 @@ use Reinfi\DependencyInjection\Config\Factory\ModuleConfigFactory;
 use Reinfi\DependencyInjection\Config\ModuleConfig;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Config\Factory
+ * @package Reinfi\DependencyInjection\Test\Unit\Config\Factory
  */
 class ModuleConfigFactoryTest extends TestCase
 {

--- a/test/Unit/ConfigProviderTest.php
+++ b/test/Unit/ConfigProviderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Reinfi\DependencyInjection\Unit;
+namespace Reinfi\DependencyInjection\Test\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Reinfi\DependencyInjection\ConfigProvider;

--- a/test/Unit/Controller/Factory/CacheWarmupControllerFactoryTest.php
+++ b/test/Unit/Controller/Factory/CacheWarmupControllerFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Controller\Factory;
+namespace Reinfi\DependencyInjection\Test\Unit\Controller\Factory;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -12,7 +12,7 @@ use Reinfi\DependencyInjection\Service\Extractor\ExtractorInterface;
 use Zend\Mvc\Controller\ControllerManager;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Controller\Factory
+ * @package Reinfi\DependencyInjection\Test\Unit\Controller\Factory
  */
 class CacheWarmupControllerFactoryTest extends TestCase
 {

--- a/test/Unit/Factory/AutoWiringFactoryTest.php
+++ b/test/Unit/Factory/AutoWiringFactoryTest.php
@@ -1,21 +1,21 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Factory;
+namespace Reinfi\DependencyInjection\Test\Unit\Factory;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Psr\Container\ContainerInterface;
 use Reinfi\DependencyInjection\Factory\AutoWiringFactory;
 use Reinfi\DependencyInjection\Service\AutoWiringService;
-use Reinfi\DependencyInjection\Service\Service1;
-use Reinfi\DependencyInjection\Service\Service2;
-use Reinfi\DependencyInjection\Service\Service3;
+use Reinfi\DependencyInjection\Test\Service\Service1;
+use Reinfi\DependencyInjection\Test\Service\Service2;
+use Reinfi\DependencyInjection\Test\Service\Service3;
 use Zend\ServiceManager\AbstractPluginManager;
 use Zend\ServiceManager\Exception\InvalidServiceException;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Factory
+ * @package Reinfi\DependencyInjection\Test\Unit\Factory
  */
 class AutoWiringFactoryTest extends TestCase
 {

--- a/test/Unit/Factory/InjectionFactoryTest.php
+++ b/test/Unit/Factory/InjectionFactoryTest.php
@@ -1,21 +1,21 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Factory;
+namespace Reinfi\DependencyInjection\Test\Unit\Factory;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Psr\Container\ContainerInterface;
 use Reinfi\DependencyInjection\Factory\InjectionFactory;
 use Reinfi\DependencyInjection\Service\InjectionService;
-use Reinfi\DependencyInjection\Service\Service1;
-use Reinfi\DependencyInjection\Service\Service2;
-use Reinfi\DependencyInjection\Service\Service3;
+use Reinfi\DependencyInjection\Test\Service\Service1;
+use Reinfi\DependencyInjection\Test\Service\Service2;
+use Reinfi\DependencyInjection\Test\Service\Service3;
 use Zend\ServiceManager\AbstractPluginManager;
 use Zend\ServiceManager\Exception\InvalidServiceException;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Factory
+ * @package Reinfi\DependencyInjection\Test\Unit\Factory
  */
 class InjectionFactoryTest extends TestCase
 {

--- a/test/Unit/Injection/AutoWiringContainerTest.php
+++ b/test/Unit/Injection/AutoWiringContainerTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Injection;
+namespace Reinfi\DependencyInjection\Test\Unit\Injection;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Reinfi\DependencyInjection\Injection\AutoWiringContainer;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Injection
+ * @package Reinfi\DependencyInjection\Test\Unit\Injection
  */
 class AutoWiringContainerTest extends TestCase
 {

--- a/test/Unit/Injection/AutoWiringPluginManagerTest.php
+++ b/test/Unit/Injection/AutoWiringPluginManagerTest.php
@@ -1,17 +1,16 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Injection;
+namespace Reinfi\DependencyInjection\Test\Unit\Injection;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Reinfi\DependencyInjection\Exception\AutoWiringNotPossibleException;
-use Reinfi\DependencyInjection\Injection\AutoWiring;
 use Reinfi\DependencyInjection\Injection\AutoWiringPluginManager;
-use Reinfi\DependencyInjection\Service\Service1;
+use Reinfi\DependencyInjection\Test\Service\Service1;
 use Zend\ServiceManager\AbstractPluginManager;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Injection
+ * @package Reinfi\DependencyInjection\Test\Unit\Injection
  */
 class AutoWiringPluginManagerTest extends TestCase
 {

--- a/test/Unit/Injection/AutoWiringTest.php
+++ b/test/Unit/Injection/AutoWiringTest.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Injection;
+namespace Reinfi\DependencyInjection\Test\Unit\Injection;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Reinfi\DependencyInjection\Exception\AutoWiringNotPossibleException;
 use Reinfi\DependencyInjection\Injection\AutoWiring;
-use Reinfi\DependencyInjection\Service\Service1;
+use Reinfi\DependencyInjection\Test\Service\Service1;
 use Zend\ServiceManager\AbstractPluginManager;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Injection
+ * @package Reinfi\DependencyInjection\Test\Unit\Injection
  */
 class AutoWiringTest extends TestCase
 {

--- a/test/Unit/ModuleTest.php
+++ b/test/Unit/ModuleTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit;
+namespace Reinfi\DependencyInjection\Test\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Reinfi\DependencyInjection\Module;
 use Zend\Console\Adapter\AdapterInterface;
 
 /**
- * @package Reinfi\DependencyInjection\Unit
+ * @package Reinfi\DependencyInjection\Test\Unit
  */
 class ModuleTest extends TestCase
 {

--- a/test/Unit/Service/AutoWiring/Factory/ResolverServiceFactoryTest.php
+++ b/test/Unit/Service/AutoWiring/Factory/ResolverServiceFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Service\AutoWiring\Factory;
+namespace Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring\Factory;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -13,11 +13,10 @@ use Reinfi\DependencyInjection\Service\AutoWiring\Resolver\PluginManagerResolver
 use Reinfi\DependencyInjection\Service\AutoWiring\Resolver\RequestResolver;
 use Reinfi\DependencyInjection\Service\AutoWiring\Resolver\ResponseResolver;
 use Reinfi\DependencyInjection\Service\AutoWiring\ResolverService;
-use Reinfi\DependencyInjection\Service\Resolver\TestResolver;
-use Zend\Config\Config;
+use Reinfi\DependencyInjection\Test\Service\Resolver\TestResolver;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Service\AutoWiring\Factory
+ * @package Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring\Factory
  */
 class ResolverServiceFactoryTest extends TestCase
 {

--- a/test/Unit/Service/AutoWiring/LazyResolverServiceTest.php
+++ b/test/Unit/Service/AutoWiring/LazyResolverServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Service\AutoWiring;
+namespace Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring;
 
 use Interop\Container\ContainerInterface;
 use PHPUnit\Framework\TestCase;
@@ -9,7 +9,7 @@ use Reinfi\DependencyInjection\Service\AutoWiring\ResolverService;
 use Reinfi\DependencyInjection\Service\AutoWiring\ResolverServiceInterface;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Service\AutoWiring
+ * @package Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring
  *
  * @group unit
  */

--- a/test/Unit/Service/AutoWiring/Resolver/BuildInTypeWithDefaultResolverTest.php
+++ b/test/Unit/Service/AutoWiring/Resolver/BuildInTypeWithDefaultResolverTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Service\AutoWiring\Resolver;
+namespace Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring\Resolver;
 
 use PHPUnit\Framework\TestCase;
 use Reinfi\DependencyInjection\Injection\InjectionInterface;
 use Reinfi\DependencyInjection\Service\AutoWiring\Resolver\BuildInTypeWithDefaultResolver;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Service\AutoWiring\Resolver
+ * @package Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring\Resolver
  */
 class BuildInTypeWithDefaultResolverTest extends TestCase
 {

--- a/test/Unit/Service/AutoWiring/Resolver/ContainerInterfaceResolverTest.php
+++ b/test/Unit/Service/AutoWiring/Resolver/ContainerInterfaceResolverTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Service\AutoWiring\Resolver;
+namespace Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring\Resolver;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -10,7 +10,7 @@ use Zend\ServiceManager\AbstractPluginManager;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Service\AutoWiring\Resolver
+ * @package Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring\Resolver
  */
 class ContainerInterfaceResolverTest extends TestCase
 {

--- a/test/Unit/Service/AutoWiring/Resolver/ContainerResolverTest.php
+++ b/test/Unit/Service/AutoWiring/Resolver/ContainerResolverTest.php
@@ -1,16 +1,15 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Service\AutoWiring\Resolver;
+namespace Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring\Resolver;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Reinfi\DependencyInjection\Injection\InjectionInterface;
 use Reinfi\DependencyInjection\Service\AutoWiring\Resolver\ContainerResolver;
-use Reinfi\DependencyInjection\Service\Extractor\ExtractorInterface;
-use Reinfi\DependencyInjection\Service\Service1;
+use Reinfi\DependencyInjection\Test\Service\Service1;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Service\AutoWiring\Resolver
+ * @package Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring\Resolver
  */
 class ContainerResolverTest extends TestCase
 {

--- a/test/Unit/Service/AutoWiring/Resolver/Factory/ContainerResolverFactoryTest.php
+++ b/test/Unit/Service/AutoWiring/Resolver/Factory/ContainerResolverFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Service\AutoWiring\Resolver\Factory;
+namespace Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring\Resolver\Factory;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -8,7 +8,7 @@ use Reinfi\DependencyInjection\Service\AutoWiring\Resolver\ContainerResolver;
 use Reinfi\DependencyInjection\Service\AutoWiring\Resolver\Factory\ContainerResolverFactory;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Service\AutoWiring\Resolver\Factory
+ * @package Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring\Resolver\Factory
  */
 class ContainerResolverFactoryTest extends TestCase
 {

--- a/test/Unit/Service/AutoWiring/Resolver/Factory/PluginManagerResolverFactoryTest.php
+++ b/test/Unit/Service/AutoWiring/Resolver/Factory/PluginManagerResolverFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Service\AutoWiring\Resolver\Factory;
+namespace Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring\Resolver\Factory;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -8,7 +8,7 @@ use Reinfi\DependencyInjection\Service\AutoWiring\Resolver\Factory\PluginManager
 use Reinfi\DependencyInjection\Service\AutoWiring\Resolver\PluginManagerResolver;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Service\AutoWiring\Resolver\Factory
+ * @package Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring\Resolver\Factory
  */
 class PluginManagerResolverFactoryTest extends TestCase
 {

--- a/test/Unit/Service/AutoWiring/Resolver/Factory/TranslatorResolverFactoryTest.php
+++ b/test/Unit/Service/AutoWiring/Resolver/Factory/TranslatorResolverFactoryTest.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Service\AutoWiring\Resolver\Factory;
+namespace Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring\Resolver\Factory;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
-use Reinfi\DependencyInjection\Service\AutoWiring\Resolver\TranslatorResolver;
 use Reinfi\DependencyInjection\Service\AutoWiring\Resolver\Factory\TranslatorResolverFactory;
+use Reinfi\DependencyInjection\Service\AutoWiring\Resolver\TranslatorResolver;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Service\AutoWiring\Resolver\Factory
+ * @package Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring\Resolver\Factory
  */
 class TranslatorResolverFactoryTest extends TestCase
 {

--- a/test/Unit/Service/AutoWiring/Resolver/PluginManagerResolverTest.php
+++ b/test/Unit/Service/AutoWiring/Resolver/PluginManagerResolverTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Service\AutoWiring\Resolver;
+namespace Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring\Resolver;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -8,10 +8,10 @@ use Reinfi\DependencyInjection\Injection\AutoWiringPluginManager;
 use Reinfi\DependencyInjection\Injection\InjectionInterface;
 use Reinfi\DependencyInjection\Service\AutoWiring\Resolver\PluginManagerResolver;
 use Reinfi\DependencyInjection\Service\Extractor\ExtractorInterface;
-use Reinfi\DependencyInjection\Service\Service1;
+use Reinfi\DependencyInjection\Test\Service\Service1;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Service\AutoWiring\Resolver
+ * @package Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring\Resolver
  */
 class PluginManagerResolverTest extends TestCase
 {

--- a/test/Unit/Service/AutoWiring/Resolver/RequestResolverTest.php
+++ b/test/Unit/Service/AutoWiring/Resolver/RequestResolverTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Service\AutoWiring\Resolver;
+namespace Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring\Resolver;
 
 use PHPUnit\Framework\TestCase;
 use Reinfi\DependencyInjection\Injection\AutoWiring;
@@ -9,7 +9,7 @@ use Zend\Http\Request;
 use Zend\Stdlib\RequestInterface;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Service\AutoWiring\Resolver
+ * @package Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring\Resolver
  */
 class RequestResolverTest extends TestCase
 {

--- a/test/Unit/Service/AutoWiring/Resolver/ResponseResolverTest.php
+++ b/test/Unit/Service/AutoWiring/Resolver/ResponseResolverTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Service\AutoWiring\Resolver;
+namespace Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring\Resolver;
 
 use PHPUnit\Framework\TestCase;
 use Reinfi\DependencyInjection\Injection\AutoWiring;
@@ -9,7 +9,7 @@ use Zend\Http\Response;
 use Zend\Stdlib\ResponseInterface;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Service\AutoWiring\Resolver
+ * @package Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring\Resolver
  */
 class ResponseResolverTest extends TestCase
 {

--- a/test/Unit/Service/AutoWiring/Resolver/TranslatorResolverTest.php
+++ b/test/Unit/Service/AutoWiring/Resolver/TranslatorResolverTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Service\AutoWiring\Resolver;
+namespace Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring\Resolver;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -12,7 +12,7 @@ use Zend\I18n\Translator\Translator;
 use Zend\I18n\Translator\TranslatorInterface;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Service\AutoWiring\Resolver
+ * @package Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring\Resolver
  */
 class TranslatorResolverTest extends TestCase
 {

--- a/test/Unit/Service/AutoWiring/ResolverServiceTest.php
+++ b/test/Unit/Service/AutoWiring/ResolverServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Service\AutoWiring;
+namespace Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring;
 
 use Interop\Container\ContainerInterface;
 use PHPUnit\Framework\TestCase;
@@ -10,13 +10,13 @@ use Reinfi\DependencyInjection\Injection\AutoWiring;
 use Reinfi\DependencyInjection\Injection\InjectionInterface;
 use Reinfi\DependencyInjection\Service\AutoWiring\Resolver\ResolverInterface;
 use Reinfi\DependencyInjection\Service\AutoWiring\ResolverService;
-use Reinfi\DependencyInjection\Service\Service1;
-use Reinfi\DependencyInjection\Service\Service2;
-use Reinfi\DependencyInjection\Service\ServiceBuildInType;
-use Reinfi\DependencyInjection\Service\ServiceNoTypeHint;
+use Reinfi\DependencyInjection\Test\Service\Service1;
+use Reinfi\DependencyInjection\Test\Service\Service2;
+use Reinfi\DependencyInjection\Test\Service\ServiceBuildInType;
+use Reinfi\DependencyInjection\Test\Service\ServiceNoTypeHint;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Service\AutoWiring
+ * @package Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring
  */
 class ResolverServiceTest extends TestCase
 {

--- a/test/Unit/Service/AutoWiringServiceTest.php
+++ b/test/Unit/Service/AutoWiringServiceTest.php
@@ -10,12 +10,12 @@ use Reinfi\DependencyInjection\Injection\InjectionInterface;
 use Reinfi\DependencyInjection\Service\AutoWiring\ResolverService;
 use Reinfi\DependencyInjection\Service\AutoWiringService;
 use Reinfi\DependencyInjection\Service\CacheService;
-use Reinfi\DependencyInjection\Service\Service1;
-use Reinfi\DependencyInjection\Service\Service2;
+use Reinfi\DependencyInjection\Test\Service\Service1;
+use Reinfi\DependencyInjection\Test\Service\Service2;
 use Reinfi\DependencyInjection\Traits\CacheKeyTrait;
 
 /**
- * @package Reinfi\DependencyInjection\Test\Unit\Service
+ * @package Reinfi\DependencyInjection\Test\Test\Unit\Service
  */
 class AutoWiringServiceTest extends TestCase
 {

--- a/test/Unit/Service/CacheServiceTest.php
+++ b/test/Unit/Service/CacheServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Service;
+namespace Reinfi\DependencyInjection\Test\Unit\Service;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -9,7 +9,7 @@ use Reinfi\DependencyInjection\Service\CacheService;
 use Zend\Cache\Storage\StorageInterface;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Service
+ * @package Reinfi\DependencyInjection\Test\Unit\Service
  */
 class CacheServiceTest extends TestCase
 {

--- a/test/Unit/Service/ConfigServiceTest.php
+++ b/test/Unit/Service/ConfigServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Service;
+namespace Reinfi\DependencyInjection\Test\Unit\Service;
 
 use PHPUnit\Framework\TestCase;
 use Reinfi\DependencyInjection\Exception\ConfigPathNotFoundException;
@@ -8,7 +8,7 @@ use Reinfi\DependencyInjection\Service\ConfigService;
 use Zend\Config\Config;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Service
+ * @package Reinfi\DependencyInjection\Test\Unit\Service
  */
 class ConfigServiceTest extends TestCase
 {

--- a/test/Unit/Service/Extractor/AnnotationExtractorTest.php
+++ b/test/Unit/Service/Extractor/AnnotationExtractorTest.php
@@ -1,18 +1,18 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Service\Extractor;
+namespace Reinfi\DependencyInjection\Test\Unit\Service\Extractor;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Reinfi\DependencyInjection\Annotation\AnnotationInterface;
 use Reinfi\DependencyInjection\Service\Extractor\AnnotationExtractor;
-use Reinfi\DependencyInjection\Service\Service1;
-use Reinfi\DependencyInjection\Service\Service2;
-use Reinfi\DependencyInjection\Service\ServiceAnnotation;
+use Reinfi\DependencyInjection\Test\Service\Service1;
+use Reinfi\DependencyInjection\Test\Service\Service2;
+use Reinfi\DependencyInjection\Test\Service\ServiceAnnotation;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Service\Extractor
+ * @package Reinfi\DependencyInjection\Test\Unit\Service\Extractor
  */
 class AnnotationExtractorTest extends TestCase
 {

--- a/test/Unit/Service/Extractor/Factory/AnnotationExtractorFactoryTest.php
+++ b/test/Unit/Service/Extractor/Factory/AnnotationExtractorFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Service\Extractor\Factory;
+namespace Reinfi\DependencyInjection\Test\Unit\Service\Extractor\Factory;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -8,7 +8,7 @@ use Reinfi\DependencyInjection\Service\Extractor\AnnotationExtractor;
 use Reinfi\DependencyInjection\Service\Extractor\Factory\AnnotationExtractorFactory;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Service\Extractor\Factory
+ * @package Reinfi\DependencyInjection\Test\Unit\Service\Extractor\Factory
  */
 class AnnotationExtractorFactoryTest extends TestCase
 {

--- a/test/Unit/Service/Extractor/Factory/ExtractorFactoryTest.php
+++ b/test/Unit/Service/Extractor/Factory/ExtractorFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Service\Extractor\Factory;
+namespace Reinfi\DependencyInjection\Test\Unit\Service\Extractor\Factory;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -11,7 +11,7 @@ use Reinfi\DependencyInjection\Service\Extractor\YamlExtractor;
 use Zend\Config\Config;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Service\Extractor\Factory
+ * @package Reinfi\DependencyInjection\Test\Unit\Service\Extractor\Factory
  */
 class ExtractorFactoryTest extends TestCase
 {

--- a/test/Unit/Service/Extractor/Factory/YamlExtractorFactoryTest.php
+++ b/test/Unit/Service/Extractor/Factory/YamlExtractorFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Service\Extractor\Factory;
+namespace Reinfi\DependencyInjection\Test\Unit\Service\Extractor\Factory;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -10,7 +10,7 @@ use Reinfi\DependencyInjection\Service\Extractor\YamlExtractor;
 use Zend\Config\Config;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Service\Extractor\Factory
+ * @package Reinfi\DependencyInjection\Test\Unit\Service\Extractor\Factory
  */
 class YamlExtractorFactoryTest extends TestCase
 {

--- a/test/Unit/Service/Extractor/YamlExtractorTest.php
+++ b/test/Unit/Service/Extractor/YamlExtractorTest.php
@@ -6,13 +6,13 @@ use PHPUnit\Framework\TestCase;
 use Reinfi\DependencyInjection\Annotation\AnnotationInterface;
 use Reinfi\DependencyInjection\Exception\InjectionTypeUnknownException;
 use Reinfi\DependencyInjection\Service\Extractor\YamlExtractor;
-use Reinfi\DependencyInjection\Service\Service1;
-use Reinfi\DependencyInjection\Service\Service2;
-use Reinfi\DependencyInjection\Service\ServiceAnnotation;
+use Reinfi\DependencyInjection\Test\Service\Service1;
+use Reinfi\DependencyInjection\Test\Service\Service2;
+use Reinfi\DependencyInjection\Test\Service\ServiceAnnotation;
 use Symfony\Component\Yaml\Yaml;
 
 /**
- * @package Reinfi\DependencyInjection\Test\Unit\Service\Extractor
+ * @package Reinfi\DependencyInjection\Test\Test\Unit\Service\Extractor
  */
 class YamlExtractorTest extends TestCase
 {
@@ -142,7 +142,7 @@ class YamlExtractorTest extends TestCase
         $extractor = new YamlExtractor(
             new Yaml(),
             __DIR__ . '/../../../resources/bad_services.yml',
-            'Reinfi\DependencyInjection\Service'
+            'Reinfi\DependencyInjection\Test\Service'
         );
 
         $extractor->getConstructorInjections(ServiceAnnotation::class);

--- a/test/Unit/Service/Factory/CacheServiceFactoryTest.php
+++ b/test/Unit/Service/Factory/CacheServiceFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Reinfi\DependencyInjection\Unit\Service\Factory;
+namespace Reinfi\DependencyInjection\Test\Unit\Service\Factory;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -10,7 +10,7 @@ use Reinfi\DependencyInjection\Service\Factory\CacheServiceFactory;
 use Zend\Cache\Storage\Adapter\Memory;
 
 /**
- * @package Reinfi\DependencyInjection\Unit\Service\Factory
+ * @package Reinfi\DependencyInjection\Test\Unit\Service\Factory
  */
 class CacheServiceFactoryTest extends TestCase
 {

--- a/test/Unit/Service/InjectionServiceTest.php
+++ b/test/Unit/Service/InjectionServiceTest.php
@@ -7,16 +7,15 @@ use Prophecy\Argument;
 use Prophecy\Prophecy\MethodProphecy;
 use Psr\Container\ContainerInterface;
 use Reinfi\DependencyInjection\Injection\InjectionInterface;
-use Reinfi\DependencyInjection\Service\AutoWiring\ResolverService;
 use Reinfi\DependencyInjection\Service\CacheService;
 use Reinfi\DependencyInjection\Service\Extractor\ExtractorInterface;
 use Reinfi\DependencyInjection\Service\InjectionService;
-use Reinfi\DependencyInjection\Service\Service1;
-use Reinfi\DependencyInjection\Service\Service2;
+use Reinfi\DependencyInjection\Test\Service\Service1;
+use Reinfi\DependencyInjection\Test\Service\Service2;
 use Reinfi\DependencyInjection\Traits\CacheKeyTrait;
 
 /**
- * @package Reinfi\DependencyInjection\Test\Unit\Service
+ * @package Reinfi\DependencyInjection\Test\Test\Unit\Service
  */
 class InjectionServiceTest extends TestCase
 {

--- a/test/resources/bad_services.yml
+++ b/test/resources/bad_services.yml
@@ -1,8 +1,8 @@
-Reinfi\DependencyInjection\Service\Service1:
-  - {value: Reinfi\DependencyInjection\Service\Service2}
+Reinfi\DependencyInjection\Test\Service\Service1:
+  - {value: Reinfi\DependencyInjection\Test\Service\Service2}
 
-Reinfi\DependencyInjection\Service\Service2:
-  - {type: InjectCoffee, value: Reinfi\DependencyInjection\Service\Service2}
+Reinfi\DependencyInjection\Test\Service\Service2:
+  - {type: InjectCoffee, value: Reinfi\DependencyInjection\Test\Service\Service2}
 
-Reinfi\DependencyInjection\Service\ServiceAnnotation:
-  - {type: BadInjectionClass, value: Reinfi\DependencyInjection\Service\Service1}
+Reinfi\DependencyInjection\Test\Service\ServiceAnnotation:
+  - {type: BadInjectionClass, value: Reinfi\DependencyInjection\Test\Service\Service1}

--- a/test/resources/config.php
+++ b/test/resources/config.php
@@ -5,15 +5,15 @@ use Zend\ServiceManager\ServiceLocatorInterface;
 return [
     'service_manager' => [
         'factories' => [
-            \Reinfi\DependencyInjection\Service\Service1::class                                   => \Reinfi\DependencyInjection\Factory\AutoWiringFactory::class,
-            \Reinfi\DependencyInjection\Service\Service2::class                                   => \Zend\ServiceManager\Factory\InvokableFactory::class,
-            \Reinfi\DependencyInjection\Service\Service3::class                                   => \Reinfi\DependencyInjection\Service\Factory\Service3Factory::class,
-            \Reinfi\DependencyInjection\Service\ServiceAnnotation::class                          => \Reinfi\DependencyInjection\Factory\InjectionFactory::class,
-            \Reinfi\DependencyInjection\Service\ServiceAnnotationConstructor::class               => \Reinfi\DependencyInjection\Factory\InjectionFactory::class,
-            \Reinfi\DependencyInjection\Service\ServiceContainer::class                           => \Reinfi\DependencyInjection\Factory\AutoWiringFactory::class,
-            \Reinfi\DependencyInjection\Service\ServiceBuildInTypeWithDefault::class              => \Reinfi\DependencyInjection\Factory\AutoWiringFactory::class,
-            \Reinfi\DependencyInjection\Service\ServiceBuildInTypeWithDefaultUsingConstant::class => \Reinfi\DependencyInjection\Factory\AutoWiringFactory::class,
-            'service_with_closure_as_factory'                                                     => function (
+            \Reinfi\DependencyInjection\Test\Service\Service1::class                                   => \Reinfi\DependencyInjection\Factory\AutoWiringFactory::class,
+            \Reinfi\DependencyInjection\Test\Service\Service2::class                                   => \Zend\ServiceManager\Factory\InvokableFactory::class,
+            \Reinfi\DependencyInjection\Test\Service\Service3::class                                   => \Reinfi\DependencyInjection\Test\Service\Factory\Service3Factory::class,
+            \Reinfi\DependencyInjection\Test\Service\ServiceAnnotation::class                          => \Reinfi\DependencyInjection\Factory\InjectionFactory::class,
+            \Reinfi\DependencyInjection\Test\Service\ServiceAnnotationConstructor::class               => \Reinfi\DependencyInjection\Factory\InjectionFactory::class,
+            \Reinfi\DependencyInjection\Test\Service\ServiceContainer::class                           => \Reinfi\DependencyInjection\Factory\AutoWiringFactory::class,
+            \Reinfi\DependencyInjection\Test\Service\ServiceBuildInTypeWithDefault::class              => \Reinfi\DependencyInjection\Factory\AutoWiringFactory::class,
+            \Reinfi\DependencyInjection\Test\Service\ServiceBuildInTypeWithDefaultUsingConstant::class => \Reinfi\DependencyInjection\Factory\AutoWiringFactory::class,
+            'service_with_closure_as_factory'                                                          => function (
                 ServiceLocatorInterface $locator
             ) {
                 return new \stdClass();

--- a/test/resources/services.yml
+++ b/test/resources/services.yml
@@ -2,9 +2,9 @@ Reinfi\DependencyInjection\Service\InjectionService:
   - {type: Inject, value: Reinfi\DependencyInjection\Service\Extractor\ExtractorInterface}
   - {type: Inject, value: Reinfi\DependencyInjection\Service\CacheService}
 
-Reinfi\DependencyInjection\Service\Service1:
-  - {type: Inject, value: Reinfi\DependencyInjection\Service\Service2}
-  - {type: Inject, value: Reinfi\DependencyInjection\Service\Service3}
+Reinfi\DependencyInjection\Test\Service\Service1:
+  - {type: Inject, value: Reinfi\DependencyInjection\Test\Service\Service2}
+  - {type: Inject, value: Reinfi\DependencyInjection\Test\Service\Service3}
 
 Reinfi\DependencyInjection\Service\ServiceDoctrine:
-  - {type: InjectDoctrineRepository, value: Reinfi\DependencyInjection\Service\Service2}
+  - {type: InjectDoctrineRepository, value: Reinfi\DependencyInjection\Test\Service\Service2}


### PR DESCRIPTION
This should solve problems with future `composer dumpautoload -o` classmap generations.

How to test:
- checkout code (master)
- run `composer dumpautoload -o`

The following messages should appear:
```
Generating optimized autoload files
Deprecation Notice: Class Reinfi\DependencyInjection\Test\Unit\Service\AutoWiringServiceTest located in ./test/Unit/Service/AutoWiringServiceTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in C
omposer v1.11+. in phar:///usr/local/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:185
Deprecation Notice: Class Reinfi\DependencyInjection\Test\Unit\Service\Extractor\YamlExtractorTest located in ./test/Unit/Service/Extractor/YamlExtractorTest.php does not comply with psr-4 autoloading standard. It will not autoload
anymore in Composer v1.11+. in phar:///usr/local/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:185
Deprecation Notice: Class Reinfi\DependencyInjection\Test\Unit\Service\InjectionServiceTest located in ./test/Unit/Service/InjectionServiceTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Com
poser v1.11+. in phar:///usr/local/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:185
```

Validate fix:
- checkout PR code
- run `composer dumpautoload -o`

No notice should popup