### PR TITLE
calling cache factory with container as an argument

### DIFF
--- a/src/Service/Factory/CacheServiceFactory.php
+++ b/src/Service/Factory/CacheServiceFactory.php
@@ -33,7 +33,7 @@ class CacheServiceFactory
         }
 
         if (is_callable($cacheConfigValue)) {
-            $cache = $cacheConfigValue();
+            $cache = $cacheConfigValue($container);
         }
 
         if (!$cache instanceof CacheInterface) {

--- a/test/Unit/Service/Factory/CacheServiceFactoryTest.php
+++ b/test/Unit/Service/Factory/CacheServiceFactoryTest.php
@@ -70,7 +70,8 @@ class CacheServiceFactoryTest extends TestCase
         $container = $this->prophesize(ContainerInterface::class);
 
         $container->get(ModuleConfig::class)
-            ->willReturn(['cache' => function () {
+            ->willReturn(['cache' => static function (ContainerInterface $containerArgument) use ($container){
+                self::assertSame($container->reveal(), $containerArgument);
                 return new Memory();
             }]);
 


### PR DESCRIPTION
Currently, the Cache factory callables do not get the container as a parameter and so cannot use already existing cache configs from the container.

This PR fixes that while not breaking already existing code with callables without parameters