### PR TITLE
allow extractors to be array of extractors instead of single one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Changelog
+### v5.5.0
+- extractor configuration can now contain an array of extractors 
 ### v5.0.0
 - deprecated PHP 7.3
 - add PHP 8.1

--- a/test/Unit/Service/Extractor/Factory/ExtractorFactoryTest.php
+++ b/test/Unit/Service/Extractor/Factory/ExtractorFactoryTest.php
@@ -73,6 +73,57 @@ class ExtractorFactoryTest extends TestCase
         self::assertContainsOnlyInstancesOf(ExtractorInterface::class, $chain);
     }
 
+    public function testItReturnsArrayOfExtractorsDefinedInConfig(): void
+    {
+        $isPhp8OrAbove = version_compare(PHP_VERSION, '8.0.0') >= 0;
+
+        $moduleConfig = new Config([
+            'extractor' => [
+                YamlExtractor::class,
+            ],
+        ]);
+
+        $yamlExtractor = $this->prophesize(YamlExtractor::class);
+        $annotationExtractor = $this->prophesize(AnnotationExtractor::class);
+        $attributeExtractor = $this->prophesize(AttributeExtractor::class);
+        $container = $this->prophesize(ContainerInterface::class);
+
+        $container->get(ModuleConfig::class)
+            ->willReturn($moduleConfig->toArray())
+            ->shouldBeCalled();
+        $container->get(YamlExtractor::class)
+            ->willReturn($yamlExtractor->reveal())
+            ->shouldBeCalled();
+        $container->get(AnnotationExtractor::class)
+            ->willReturn($annotationExtractor->reveal())
+            ->shouldBeCalled();
+        $container->get(AttributeExtractor::class)
+            ->willReturn($attributeExtractor->reveal())
+            ->shouldBeCalledTimes($isPhp8OrAbove ? 1 : 0);
+
+        $factory = new ExtractorFactory();
+
+        $extractor = $factory($container->reveal());
+
+        self::assertInstanceOf(ExtractorChain::class, $extractor);
+
+        $reflectionClass = new ReflectionClass($extractor);
+        $chainProperty = $reflectionClass->getProperty('chain');
+        $chainProperty->setAccessible(true);
+
+        $chain = $chainProperty->getValue($extractor);
+
+        self::assertTrue(is_array($chain));
+
+        if ($isPhp8OrAbove) {
+            self::assertCount(3, $chain);
+        } else {
+            self::assertCount(2, $chain);
+        }
+
+        self::assertContainsOnlyInstancesOf(ExtractorInterface::class, $chain);
+    }
+
     public function testItReturnsAnnotationExtractorIfNoneDefined(): void
     {
         $isPhp8OrAbove = version_compare(PHP_VERSION, '8.0.0') >= 0;


### PR DESCRIPTION
Allow extractor configuration to be array of extractors. For backwards compatibility a single string value is still allowed.