### PR TITLE
register new interface for translator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,8 @@
         "laminas/laminas-inputfilter": "^2.12",
         "bnf/phpstan-psr-container": "^1.0",
         "symplify/easy-coding-standard": "^12.0",
-        "doctrine/annotations": "^2.0"
+        "doctrine/annotations": "^2.0",
+        "laminas/laminas-translator": "^1.0"
     },
     "extra": {
         "zf": {

--- a/src/AbstractFactory/FallbackAutoWiringFactory.php
+++ b/src/AbstractFactory/FallbackAutoWiringFactory.php
@@ -9,8 +9,6 @@ use Laminas\ServiceManager\Factory\AbstractFactoryInterface;
 use Reinfi\DependencyInjection\Factory\AutoWiringFactory;
 
 /**
- * Class FallbackAutoWiringFactory
- *
  * Note: Please DO NOT use this factory for everything.
  * If you're implementing new classes, please write a concrete factory.
  *

--- a/src/Injection/InjectionInterface.php
+++ b/src/Injection/InjectionInterface.php
@@ -7,8 +7,6 @@ namespace Reinfi\DependencyInjection\Injection;
 use Psr\Container\ContainerInterface;
 
 /**
- * Interface InjectionInterface
- *
  * @package Reinfi\DependencyInjection\Injection
  */
 interface InjectionInterface

--- a/src/Service/AutoWiring/Resolver/TranslatorResolver.php
+++ b/src/Service/AutoWiring/Resolver/TranslatorResolver.php
@@ -17,14 +17,24 @@ use Reinfi\DependencyInjection\Injection\InjectionInterface;
 class TranslatorResolver implements ResolverInterface
 {
     /**
-     * used to avoid requirement of laminas/laminas-i18n module
+     * used to avoid requirement of laminas/laminas-i18n module, deprecated interface name.
      */
-    private const TRANSLATOR_INTERFACE = 'Laminas\I18n\Translator\TranslatorInterface';
+    private const TRANSLATOR_INTERFACE_OLD = 'Laminas\I18n\Translator\TranslatorInterface';
+
+    /**
+     * used to avoid requirement of laminas/laminas-translator module.
+     */
+    private const TRANSLATOR_INTERFACE = 'Laminas\Translator\TranslatorInterface';
 
     /**
      * possible names for translator service within container
      */
-    private const TRANSLATOR_CONTAINER_SERVICE_NAME = ['MvcTranslator', self::TRANSLATOR_INTERFACE, 'Translator'];
+    private const TRANSLATOR_CONTAINER_SERVICE_NAME = [
+        self::TRANSLATOR_INTERFACE,
+        'MvcTranslator',
+        self::TRANSLATOR_INTERFACE_OLD,
+        'Translator',
+    ];
 
     private ContainerInterface $container;
 
@@ -65,7 +75,9 @@ class TranslatorResolver implements ResolverInterface
         $reflectionClass = new ReflectionClass($type->getName());
         $interfaceNames = $reflectionClass->getInterfaceNames();
 
-        return $reflectionClass->getName() === self::TRANSLATOR_INTERFACE
+        return $reflectionClass->getName() === self::TRANSLATOR_INTERFACE_OLD
+            || in_array(self::TRANSLATOR_INTERFACE_OLD, $interfaceNames, true)
+            || $reflectionClass->getName() === self::TRANSLATOR_INTERFACE
             || in_array(self::TRANSLATOR_INTERFACE, $interfaceNames, true)
         ;
     }

--- a/src/Service/Extractor/ExtractorInterface.php
+++ b/src/Service/Extractor/ExtractorInterface.php
@@ -7,8 +7,6 @@ namespace Reinfi\DependencyInjection\Service\Extractor;
 use Reinfi\DependencyInjection\Injection\InjectionInterface;
 
 /**
- * Interface ExtractorInterface
- *
  * @package Reinfi\DependencyInjection\Service\Extractor
  */
 interface ExtractorInterface

--- a/src/Traits/CacheKeyTrait.php
+++ b/src/Traits/CacheKeyTrait.php
@@ -7,8 +7,6 @@ namespace Reinfi\DependencyInjection\Traits;
 use Reinfi\DependencyInjection\Config\ModuleConfig;
 
 /**
- * Trait CacheKeyTrait
- *
  * @package Reinfi\DependencyInjection\Traits
  */
 trait CacheKeyTrait

--- a/test/Unit/Service/AutoWiring/Resolver/TranslatorResolverTest.php
+++ b/test/Unit/Service/AutoWiring/Resolver/TranslatorResolverTest.php
@@ -81,6 +81,7 @@ class TranslatorResolverTest extends TestCase
 
         $container->has('MvcTranslator')->willReturn(false);
         $container->has(TranslatorInterface::class)->willReturn(false);
+        $container->has(\Laminas\Translator\TranslatorInterface::class)->willReturn(false);
         $container->has('Translator')->willReturn(false);
 
         $resolver = new TranslatorResolver($container->reveal());
@@ -141,17 +142,25 @@ class TranslatorResolverTest extends TestCase
         return [
             [
                 [
+                    'Laminas\Translator\TranslatorInterface' => true,
+                ],
+            ],
+            [
+                [
+                    'Laminas\Translator\TranslatorInterface' => false,
                     'MvcTranslator' => true,
                 ],
             ],
             [
                 [
+                    'Laminas\Translator\TranslatorInterface' => false,
                     'MvcTranslator' => false,
                     'Laminas\I18n\Translator\TranslatorInterface' => true,
                 ],
             ],
             [
                 [
+                    'Laminas\Translator\TranslatorInterface' => false,
                     'MvcTranslator' => false,
                     'Laminas\I18n\Translator\TranslatorInterface' => false,
                     'Translator' => true,


### PR DESCRIPTION
In https://github.com/laminas/laminas-i18n/releases/tag/2.27.0 the TranslatorInterface is deprecated and changed. Thus we need to support both. 