### PR TITLE
update phpstan to latest version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "doctrine/orm": "^2.5",
         "php-coveralls/php-coveralls": "^2.0",
         "symfony/yaml": "^6.0 | ^7.0",
-        "phpstan/phpstan": "^1.3",
+        "phpstan/phpstan": "^2.0",
         "phpspec/prophecy-phpunit": "^2.0",
         "laminas/laminas-hydrator": "^4.2",
         "laminas/laminas-validator": "^2.14",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,13 +1,35 @@
 parameters:
     level: max
-    checkMissingIterableValueType: false
-    checkGenericClassInNonGenericObjectType: false
     paths:
         - src
     excludePaths:
         analyse:
+            - %currentWorkingDirectory%/src/Annotation
             - %currentWorkingDirectory%/src/Command*
             - %currentWorkingDirectory%/src/Service/Extractor/AttributeExtractor.php
+            - %currentWorkingDirectory%/src/Service/Extractor/Factory/YamlExtractorFactory.php
+            - %currentWorkingDirectory%/src/Service/Extractor/YamlExtractor.php
+    ignoreErrors:
+        - message: '#Parameter \#1 \$configPath of method Reinfi\\DependencyInjection\\Service\\ConfigService::resolve\(\) expects string, mixed given\.#'
+          path: src/AbstractFactory/Config/InjectConfigAbstractFactory.php
+        - message: '#Parameter \#1 \$id of method Psr\\Container\\ContainerInterface::get\(\) expects string, mixed given\.#'
+          path: src/Attribute/AbstractInjectPluginManager.php
+        - message: '#Parameter \#1 \$pluginManager of static method Reinfi\\DependencyInjection\\Exception\\InjectionNotPossibleException::fromUnknownPluginManager\(\) expects string, mixed given\.#'
+          path: src/Attribute/AbstractInjectPluginManager.php
+        - message: '#Method Reinfi\\DependencyInjection\\Extension\\PHPStan\\Resolve\\AutoWiringClassesResolver::findAutowiredClasses\(\) should return array<string> but returns array\.#'
+          path: src/Extension/PHPStan/Resolve/AutoWiringClassesResolver.php
+        - message: '#Method Reinfi\\DependencyInjection\\Module::getConfig\(\) should return array but returns mixed\.#'
+          path: src/Module.php
+        - message: '#Method Reinfi\\DependencyInjection\\Service\\Extractor\\ExtractorChain::(getPropertiesInjections|getConstructorInjections)\(\) should return array<.*InjectionInterface> but returns array\.#'
+          path: src/Service/Extractor/ExtractorChain.php
+        - message: '#Trait Reinfi\\DependencyInjection\\Traits\\WarmupTrait is used zero times and is not analysed\.#'
+          path: src/Traits/WarmupTrait.php
+        - message: '#.*#'
+          reportUnmatched: true
+          identifier: 'missingType.generics'
+        - message: '#.*#'
+          reportUnmatched: true
+          identifier: 'missingType.iterableValue'
 
 includes:
     - vendor/bnf/phpstan-psr-container/extension.neon

--- a/src/Attribute/InjectDoctrineRepository.php
+++ b/src/Attribute/InjectDoctrineRepository.php
@@ -17,8 +17,14 @@ final class InjectDoctrineRepository extends AbstractAttribute
 {
     private string $entityManager = 'Doctrine\ORM\EntityManager';
 
+    /**
+     * @var class-string<object>
+     */
     private string $entity;
 
+    /**
+     * @param class-string<object> $entity
+     */
     public function __construct(string $entity, ?string $entityManager = null)
     {
         $this->entity = $entity;
@@ -37,6 +43,7 @@ final class InjectDoctrineRepository extends AbstractAttribute
         if (
             ! is_object($entityManager)
             || ! method_exists($entityManager, 'getRepository')
+            || ! is_a($entityManager, 'Doctrine\ORM\EntityManagerInterface')
         ) {
             throw new AutoWiringNotPossibleException($this->entity);
         }

--- a/src/Extension/PHPStan/Resolve/AutoWiringClassesResolver.php
+++ b/src/Extension/PHPStan/Resolve/AutoWiringClassesResolver.php
@@ -31,6 +31,9 @@ class AutoWiringClassesResolver
         return in_array($className, $this->autowiredClasses, true);
     }
 
+    /**
+     * @return string[]
+     */
     private function findAutowiredClasses(): array
     {
         $serviceManager = $this->serviceManagerLoader->getServiceLocator();

--- a/src/Extension/PHPStan/Rules/AutoWiringPossibleRule.php
+++ b/src/Extension/PHPStan/Rules/AutoWiringPossibleRule.php
@@ -6,7 +6,9 @@ namespace Reinfi\DependencyInjection\Extension\PHPStan\Rules;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
 use Reinfi\DependencyInjection\Exception\AutoWiringNotPossibleException;
 use Reinfi\DependencyInjection\Extension\PHPStan\Resolve\AutoWiringClassesResolver;
 use Reinfi\DependencyInjection\Extension\PHPStan\Resolve\AutoWiringPossibleResolver;
@@ -32,7 +34,7 @@ final class AutoWiringPossibleRule implements Rule
 
     /**
      * @param Node\Stmt\Class_ $node
-     * @return string[]
+     * @return IdentifierRuleError[]
      */
     public function processNode(Node $node, Scope $scope): array
     {
@@ -48,11 +50,11 @@ final class AutoWiringPossibleRule implements Rule
             $this->possibleResolver->resolve($node->namespacedName->toString());
         } catch (AutoWiringNotPossibleException $exception) {
             return [
-                sprintf(
+                RuleErrorBuilder::message(sprintf(
                     'AutoWiring of %s not possible, due to: %s',
                     $node->namespacedName->toString(),
                     $exception->getMessage()
-                ),
+                ))->identifier('autowiring.notPossible')->build(),
             ];
         }
 

--- a/src/Service/AutoWiring/Factory/ResolverServiceFactory.php
+++ b/src/Service/AutoWiring/Factory/ResolverServiceFactory.php
@@ -47,6 +47,7 @@ class ResolverServiceFactory
             BuildInTypeWithDefaultResolver::class,
         ];
 
+        /** @var class-string<ResolverInterface>[]|null $resolverStackConfig */
         $resolverStackConfig = $config['autowire_resolver'] ?? null;
         if ($resolverStackConfig === null) {
             return $defaultResolverStackConfig;

--- a/src/Service/AutoWiringService.php
+++ b/src/Service/AutoWiringService.php
@@ -29,7 +29,7 @@ class AutoWiringService
     }
 
     /**
-     * @return InjectionInterface[]|null
+     * @return mixed[]|null
      */
     public function resolveConstructorInjection(
         ContainerInterface $container,
@@ -60,6 +60,7 @@ class AutoWiringService
             $cachedItem = $this->cache->get($cacheKey);
 
             if (is_array($cachedItem)) {
+                // @phpstan-ignore-next-line
                 return $cachedItem;
             }
         }

--- a/src/Service/ConfigService.php
+++ b/src/Service/ConfigService.php
@@ -45,6 +45,10 @@ class ConfigService
     {
         $currentKey = array_shift($configParts);
 
+        if (! is_string($currentKey)) {
+            throw new ConfigPathNotFoundException('invalid key');
+        }
+
         if (! $config->offsetExists($currentKey)) {
             if ($nullAllowed) {
                 return null;

--- a/src/Service/Extractor/ExtractorChain.php
+++ b/src/Service/Extractor/ExtractorChain.php
@@ -4,18 +4,26 @@ declare(strict_types=1);
 
 namespace Reinfi\DependencyInjection\Service\Extractor;
 
+use Reinfi\DependencyInjection\Injection\InjectionInterface;
+
 class ExtractorChain implements ExtractorInterface
 {
     /**
-     * @var array<int, ExtractorInterface>
+     * @var array<ExtractorInterface>
      */
     private array $chain;
 
+    /**
+     * @param array<ExtractorInterface> $chain
+     */
     public function __construct(array $chain)
     {
         $this->chain = $chain;
     }
 
+    /**
+     * @return InjectionInterface[]
+     */
     public function getPropertiesInjections(string $className): array
     {
         return array_reduce(
@@ -31,6 +39,9 @@ class ExtractorChain implements ExtractorInterface
         );
     }
 
+    /**
+     * @return InjectionInterface[]
+     */
     public function getConstructorInjections(string $className): array
     {
         return array_reduce(

--- a/src/Service/Extractor/ExtractorInterface.php
+++ b/src/Service/Extractor/ExtractorInterface.php
@@ -20,6 +20,8 @@ interface ExtractorInterface
 
     /**
      * @param class-string $className
+     *
+     * @return InjectionInterface[]
      */
     public function getConstructorInjections(string $className): array;
 }

--- a/src/Service/Extractor/Factory/ExtractorFactory.php
+++ b/src/Service/Extractor/Factory/ExtractorFactory.php
@@ -54,6 +54,7 @@ class ExtractorFactory
             $extractorConfiguration = [$extractorConfiguration];
         }
 
+        /** @var string[] $extractorConfiguration */
         return array_map(
             function (string $extractorClassName) use ($container): ExtractorInterface {
                 $extractor = $container->get($extractorClassName);

--- a/src/Service/InjectionService.php
+++ b/src/Service/InjectionService.php
@@ -61,6 +61,7 @@ class InjectionService
             $cachedItem = $this->cache->get($cacheKey);
 
             if (is_array($cachedItem)) {
+                // @phpstan-ignore-next-line
                 return $cachedItem;
             }
         }


### PR DESCRIPTION
update phpstan to latest version

- ignore annotation errors as they got deprecated with the upcoming release
- ignore some errors I will target later with the update to support only PHP 8.3