### PR TITLE
Deprecate annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Changelog
+### v7.0.0
+- annotations will be deprecated, use attributes instead
 ### v6.0.0
 - minimum required PHP version 8.1
 - added return types where possible

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Configure dependency injection in Laminas or Mezzio using annotations, yaml or autowiring.
+Configure dependency injection in Laminas or Mezzio using attributes (PHP 8.0+), yaml or autowiring.
 
 Heavily inspired by https://github.com/mikemix/mxdiModule.
 
@@ -7,7 +7,7 @@ Heavily inspired by https://github.com/mikemix/mxdiModule.
 1. [Installation](#installation)
 2. [AutoWiring](#autowiring)
 3. [Attributes](#attributes)
-4. [Annotations](#annotations)
+4. [Annotations (Deprecated)](#annotations)
 5. [YAML](#yaml)
 6. [Caching](#caching)
 7. [PHPStan Extension](#phpstan-extension)
@@ -124,7 +124,9 @@ public function __construct(MyService $service)
 ```
 The order is important and you should decide between constructor or property annotations.
 
-### Annotations
+### Annotations (Deprecated)
+> **Note**: Annotations are deprecated and will be removed in a future version. Please use Attributes instead, which provide the same functionality with a more modern syntax.
+
 To use annotations for your dependencies you need to specify the 'InjectionFactory' within the service manager configuration.
 ```php
 'service_manager' => [

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "doctrine/orm": "^2.5",
         "php-coveralls/php-coveralls": "^2.0",
         "symfony/yaml": "^6.0 | ^7.0",
-        "phpstan/phpstan": "^1.3",
+        "phpstan/phpstan": "^2.0",
         "phpspec/prophecy-phpunit": "^2.0",
         "laminas/laminas-hydrator": "^4.2",
         "laminas/laminas-validator": "^2.14",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,13 +1,35 @@
 parameters:
     level: max
-    checkMissingIterableValueType: false
-    checkGenericClassInNonGenericObjectType: false
     paths:
         - src
     excludePaths:
         analyse:
+            - %currentWorkingDirectory%/src/Annotation
             - %currentWorkingDirectory%/src/Command*
             - %currentWorkingDirectory%/src/Service/Extractor/AttributeExtractor.php
+            - %currentWorkingDirectory%/src/Service/Extractor/Factory/YamlExtractorFactory.php
+            - %currentWorkingDirectory%/src/Service/Extractor/YamlExtractor.php
+    ignoreErrors:
+        - message: '#Parameter \#1 \$configPath of method Reinfi\\DependencyInjection\\Service\\ConfigService::resolve\(\) expects string, mixed given\.#'
+          path: src/AbstractFactory/Config/InjectConfigAbstractFactory.php
+        - message: '#Parameter \#1 \$id of method Psr\\Container\\ContainerInterface::get\(\) expects string, mixed given\.#'
+          path: src/Attribute/AbstractInjectPluginManager.php
+        - message: '#Parameter \#1 \$pluginManager of static method Reinfi\\DependencyInjection\\Exception\\InjectionNotPossibleException::fromUnknownPluginManager\(\) expects string, mixed given\.#'
+          path: src/Attribute/AbstractInjectPluginManager.php
+        - message: '#Method Reinfi\\DependencyInjection\\Extension\\PHPStan\\Resolve\\AutoWiringClassesResolver::findAutowiredClasses\(\) should return array<string> but returns array\.#'
+          path: src/Extension/PHPStan/Resolve/AutoWiringClassesResolver.php
+        - message: '#Method Reinfi\\DependencyInjection\\Module::getConfig\(\) should return array but returns mixed\.#'
+          path: src/Module.php
+        - message: '#Method Reinfi\\DependencyInjection\\Service\\Extractor\\ExtractorChain::(getPropertiesInjections|getConstructorInjections)\(\) should return array<.*InjectionInterface> but returns array\.#'
+          path: src/Service/Extractor/ExtractorChain.php
+        - message: '#Trait Reinfi\\DependencyInjection\\Traits\\WarmupTrait is used zero times and is not analysed\.#'
+          path: src/Traits/WarmupTrait.php
+        - message: '#.*#'
+          reportUnmatched: true
+          identifier: 'missingType.generics'
+        - message: '#.*#'
+          reportUnmatched: true
+          identifier: 'missingType.iterableValue'
 
 includes:
     - vendor/bnf/phpstan-psr-container/extension.neon

--- a/src/Annotation/Inject.php
+++ b/src/Annotation/Inject.php
@@ -11,10 +11,21 @@ use Psr\Container\ContainerInterface;
  *
  * @Annotation
  * @Target({"PROPERTY", "METHOD"})
+ * @deprecated 2.0.0 Use \Reinfi\DependencyInjection\Attribute\Inject instead
  */
 final class Inject implements AnnotationInterface
 {
     public string $value;
+
+    public function __construct()
+    {
+        trigger_deprecation(
+            'reinfi/dependency-injection',
+            '2.0.0',
+            'The %s annotation is deprecated. Use \Reinfi\DependencyInjection\Attribute\Inject instead.',
+            self::class
+        );
+    }
 
     public function __invoke(ContainerInterface $container): mixed
     {

--- a/src/Annotation/InjectConfig.php
+++ b/src/Annotation/InjectConfig.php
@@ -10,6 +10,7 @@ use Reinfi\DependencyInjection\Service\ConfigService;
 
 /**
  * @package Reinfi\DependencyInjection\Annotation
+ * @deprecated 7.0.0 Use attributes from \Reinfi\DependencyInjection\Attribute namespace instead. Will be removed in 8.0.0.
  *
  * @Annotation
  * @Target({"PROPERTY", "METHOD"})

--- a/src/Annotation/InjectConstant.php
+++ b/src/Annotation/InjectConstant.php
@@ -8,6 +8,7 @@ use Psr\Container\ContainerInterface;
 
 /**
  * @package Reinfi\DependencyInjection\Annotation
+ * @deprecated 7.0.0 Use attributes from \Reinfi\DependencyInjection\Attribute namespace instead. Will be removed in 8.0.0.
  *
  * @Annotation
  * @Target({"PROPERTY", "METHOD"})

--- a/src/Annotation/InjectContainer.php
+++ b/src/Annotation/InjectContainer.php
@@ -8,6 +8,7 @@ use Psr\Container\ContainerInterface;
 
 /**
  * @package Reinfi\DependencyInjection\Annotation
+ * @deprecated 7.0.0 Use attributes from \Reinfi\DependencyInjection\Attribute namespace instead. Will be removed in 8.0.0.
  *
  * @Annotation
  * @Target({"PROPERTY", "METHOD"})

--- a/src/Annotation/InjectControllerPlugin.php
+++ b/src/Annotation/InjectControllerPlugin.php
@@ -6,6 +6,7 @@ namespace Reinfi\DependencyInjection\Annotation;
 
 /**
  * @package Reinfi\DependencyInjection\Annotation
+ * @deprecated 7.0.0 Use attributes from \Reinfi\DependencyInjection\Attribute namespace instead. Will be removed in 8.0.0.
  *
  * @Annotation
  * @Target({"PROPERTY", "METHOD"})

--- a/src/Annotation/InjectDoctrineRepository.php
+++ b/src/Annotation/InjectDoctrineRepository.php
@@ -10,6 +10,7 @@ use Reinfi\DependencyInjection\Exception\AutoWiringNotPossibleException;
 
 /**
  * @package Reinfi\DependencyInjection\Annotation
+ * @deprecated 7.0.0 Use attributes from \Reinfi\DependencyInjection\Attribute namespace instead. Will be removed in 8.0.0.
  *
  * @Annotation
  * @Target({"PROPERTY", "METHOD"})

--- a/src/Annotation/InjectFilter.php
+++ b/src/Annotation/InjectFilter.php
@@ -6,6 +6,7 @@ namespace Reinfi\DependencyInjection\Annotation;
 
 /**
  * @package Reinfi\DependencyInjection\Annotation
+ * @deprecated 7.0.0 Use attributes from \Reinfi\DependencyInjection\Attribute namespace instead. Will be removed in 8.0.0.
  *
  * @Annotation
  * @Target({"PROPERTY", "METHOD"})

--- a/src/Annotation/InjectFormElement.php
+++ b/src/Annotation/InjectFormElement.php
@@ -7,7 +7,7 @@ namespace Reinfi\DependencyInjection\Annotation;
 /**
  * @package Reinfi\DependencyInjection\Annotation
  * @deprecated 7.0.0 Use attributes from \Reinfi\DependencyInjection\Attribute namespace instead. Will be removed in 8.0.0.
-  *
+ *
  * @Annotation
  * @Target({"PROPERTY", "METHOD"})
  */

--- a/src/Annotation/InjectFormElement.php
+++ b/src/Annotation/InjectFormElement.php
@@ -6,7 +6,8 @@ namespace Reinfi\DependencyInjection\Annotation;
 
 /**
  * @package Reinfi\DependencyInjection\Annotation
- *
+ * @deprecated 7.0.0 Use attributes from \Reinfi\DependencyInjection\Attribute namespace instead. Will be removed in 8.0.0.
+  *
  * @Annotation
  * @Target({"PROPERTY", "METHOD"})
  */

--- a/src/Annotation/InjectHydrator.php
+++ b/src/Annotation/InjectHydrator.php
@@ -6,6 +6,7 @@ namespace Reinfi\DependencyInjection\Annotation;
 
 /**
  * @package Reinfi\DependencyInjection\Annotation
+ * @deprecated 7.0.0 Use attributes from \Reinfi\DependencyInjection\Attribute namespace instead. Will be removed in 8.0.0.
  *
  * @Annotation
  * @Target({"PROPERTY", "METHOD"})

--- a/src/Annotation/InjectInputFilter.php
+++ b/src/Annotation/InjectInputFilter.php
@@ -6,6 +6,7 @@ namespace Reinfi\DependencyInjection\Annotation;
 
 /**
  * @package Reinfi\DependencyInjection\Annotation
+ * @deprecated 7.0.0 Use attributes from \Reinfi\DependencyInjection\Attribute namespace instead. Will be removed in 8.0.0.
  *
  * @Annotation
  * @Target({"PROPERTY", "METHOD"})

--- a/src/Annotation/InjectParent.php
+++ b/src/Annotation/InjectParent.php
@@ -9,6 +9,7 @@ use Psr\Container\ContainerInterface;
 
 /**
  * @package Reinfi\DependencyInjection\Annotation
+ * @deprecated 7.0.0 Use attributes from \Reinfi\DependencyInjection\Attribute namespace instead. Will be removed in 8.0.0.
  *
  * @Annotation
  * @Target({"PROPERTY", "METHOD"})

--- a/src/Annotation/InjectValidator.php
+++ b/src/Annotation/InjectValidator.php
@@ -6,6 +6,7 @@ namespace Reinfi\DependencyInjection\Annotation;
 
 /**
  * @package Reinfi\DependencyInjection\Annotation
+ * @deprecated 7.0.0 Use attributes from \Reinfi\DependencyInjection\Attribute namespace instead. Will be removed in 8.0.0.
  *
  * @Annotation
  * @Target({"PROPERTY", "METHOD"})

--- a/src/Annotation/InjectViewHelper.php
+++ b/src/Annotation/InjectViewHelper.php
@@ -6,6 +6,7 @@ namespace Reinfi\DependencyInjection\Annotation;
 
 /**
  * @package Reinfi\DependencyInjection\Annotation
+ * @deprecated 7.0.0 Use attributes from \Reinfi\DependencyInjection\Attribute namespace instead. Will be removed in 8.0.0.
  *
  * @Annotation
  * @Target({"PROPERTY", "METHOD"})

--- a/src/Attribute/InjectDoctrineRepository.php
+++ b/src/Attribute/InjectDoctrineRepository.php
@@ -17,8 +17,14 @@ final class InjectDoctrineRepository extends AbstractAttribute
 {
     private string $entityManager = 'Doctrine\ORM\EntityManager';
 
+    /**
+     * @var class-string<object>
+     */
     private string $entity;
 
+    /**
+     * @param class-string<object> $entity
+     */
     public function __construct(string $entity, ?string $entityManager = null)
     {
         $this->entity = $entity;
@@ -37,6 +43,7 @@ final class InjectDoctrineRepository extends AbstractAttribute
         if (
             ! is_object($entityManager)
             || ! method_exists($entityManager, 'getRepository')
+            || ! is_a($entityManager, 'Doctrine\ORM\EntityManagerInterface')
         ) {
             throw new AutoWiringNotPossibleException($this->entity);
         }

--- a/src/Extension/PHPStan/Resolve/AutoWiringClassesResolver.php
+++ b/src/Extension/PHPStan/Resolve/AutoWiringClassesResolver.php
@@ -31,6 +31,9 @@ class AutoWiringClassesResolver
         return in_array($className, $this->autowiredClasses, true);
     }
 
+    /**
+     * @return string[]
+     */
     private function findAutowiredClasses(): array
     {
         $serviceManager = $this->serviceManagerLoader->getServiceLocator();

--- a/src/Extension/PHPStan/Rules/AutoWiringPossibleRule.php
+++ b/src/Extension/PHPStan/Rules/AutoWiringPossibleRule.php
@@ -6,7 +6,9 @@ namespace Reinfi\DependencyInjection\Extension\PHPStan\Rules;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
 use Reinfi\DependencyInjection\Exception\AutoWiringNotPossibleException;
 use Reinfi\DependencyInjection\Extension\PHPStan\Resolve\AutoWiringClassesResolver;
 use Reinfi\DependencyInjection\Extension\PHPStan\Resolve\AutoWiringPossibleResolver;
@@ -32,7 +34,7 @@ final class AutoWiringPossibleRule implements Rule
 
     /**
      * @param Node\Stmt\Class_ $node
-     * @return string[]
+     * @return IdentifierRuleError[]
      */
     public function processNode(Node $node, Scope $scope): array
     {
@@ -48,11 +50,11 @@ final class AutoWiringPossibleRule implements Rule
             $this->possibleResolver->resolve($node->namespacedName->toString());
         } catch (AutoWiringNotPossibleException $exception) {
             return [
-                sprintf(
+                RuleErrorBuilder::message(sprintf(
                     'AutoWiring of %s not possible, due to: %s',
                     $node->namespacedName->toString(),
                     $exception->getMessage()
-                ),
+                ))->identifier('autowiring.notPossible')->build(),
             ];
         }
 

--- a/src/Service/AutoWiring/Factory/ResolverServiceFactory.php
+++ b/src/Service/AutoWiring/Factory/ResolverServiceFactory.php
@@ -47,6 +47,7 @@ class ResolverServiceFactory
             BuildInTypeWithDefaultResolver::class,
         ];
 
+        /** @var class-string<ResolverInterface>[]|null $resolverStackConfig */
         $resolverStackConfig = $config['autowire_resolver'] ?? null;
         if ($resolverStackConfig === null) {
             return $defaultResolverStackConfig;

--- a/src/Service/AutoWiringService.php
+++ b/src/Service/AutoWiringService.php
@@ -29,7 +29,7 @@ class AutoWiringService
     }
 
     /**
-     * @return InjectionInterface[]|null
+     * @return mixed[]|null
      */
     public function resolveConstructorInjection(
         ContainerInterface $container,
@@ -60,6 +60,7 @@ class AutoWiringService
             $cachedItem = $this->cache->get($cacheKey);
 
             if (is_array($cachedItem)) {
+                // @phpstan-ignore-next-line
                 return $cachedItem;
             }
         }

--- a/src/Service/ConfigService.php
+++ b/src/Service/ConfigService.php
@@ -45,6 +45,10 @@ class ConfigService
     {
         $currentKey = array_shift($configParts);
 
+        if (! is_string($currentKey)) {
+            throw new ConfigPathNotFoundException('invalid key');
+        }
+
         if (! $config->offsetExists($currentKey)) {
             if ($nullAllowed) {
                 return null;

--- a/src/Service/Extractor/ExtractorChain.php
+++ b/src/Service/Extractor/ExtractorChain.php
@@ -4,18 +4,26 @@ declare(strict_types=1);
 
 namespace Reinfi\DependencyInjection\Service\Extractor;
 
+use Reinfi\DependencyInjection\Injection\InjectionInterface;
+
 class ExtractorChain implements ExtractorInterface
 {
     /**
-     * @var array<int, ExtractorInterface>
+     * @var array<ExtractorInterface>
      */
     private array $chain;
 
+    /**
+     * @param array<ExtractorInterface> $chain
+     */
     public function __construct(array $chain)
     {
         $this->chain = $chain;
     }
 
+    /**
+     * @return InjectionInterface[]
+     */
     public function getPropertiesInjections(string $className): array
     {
         return array_reduce(
@@ -31,6 +39,9 @@ class ExtractorChain implements ExtractorInterface
         );
     }
 
+    /**
+     * @return InjectionInterface[]
+     */
     public function getConstructorInjections(string $className): array
     {
         return array_reduce(

--- a/src/Service/Extractor/ExtractorInterface.php
+++ b/src/Service/Extractor/ExtractorInterface.php
@@ -20,6 +20,8 @@ interface ExtractorInterface
 
     /**
      * @param class-string $className
+     *
+     * @return InjectionInterface[]
      */
     public function getConstructorInjections(string $className): array;
 }

--- a/src/Service/Extractor/Factory/ExtractorFactory.php
+++ b/src/Service/Extractor/Factory/ExtractorFactory.php
@@ -54,6 +54,7 @@ class ExtractorFactory
             $extractorConfiguration = [$extractorConfiguration];
         }
 
+        /** @var string[] $extractorConfiguration */
         return array_map(
             function (string $extractorClassName) use ($container): ExtractorInterface {
                 $extractor = $container->get($extractorClassName);

--- a/src/Service/InjectionService.php
+++ b/src/Service/InjectionService.php
@@ -61,6 +61,7 @@ class InjectionService
             $cachedItem = $this->cache->get($cacheKey);
 
             if (is_array($cachedItem)) {
+                // @phpstan-ignore-next-line
                 return $cachedItem;
             }
         }


### PR DESCRIPTION
Annotations are now deprecated and will be removed in version 8.0. You should use Attributes instead.