### PR TITLE
Rectorify the code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -79,6 +79,7 @@
         "phpstan": "./vendor/bin/phpstan analyse -c phpstan.neon",
         "test": "vendor/bin/phpunit --no-coverage",
         "test-with-coverage": "vendor/bin/phpunit --coverage-clover=build/coverage.xml",
-        "infection": "infection --test-framework-options=\" --exclude-group integration\" --threads=4"
+        "infection": "infection --test-framework-options=\" --exclude-group integration\" --threads=4",
+        "rector": "vendor/bin/rector process --config rector.config.php"
     }
 }

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -2,32 +2,65 @@
 
 declare(strict_types=1);
 
+use Laminas\ServiceManager\Factory\InvokableFactory;
+use Reinfi\DependencyInjection\AbstractFactory\Config\InjectConfigAbstractFactory;
+use Reinfi\DependencyInjection\Command\CacheWarmupCommand;
+use Reinfi\DependencyInjection\Config\Factory\ModuleConfigFactory;
+use Reinfi\DependencyInjection\Config\ModuleConfig;
+use Reinfi\DependencyInjection\Service\AutoWiring\Factory\LazyResolverServiceFactory;
+use Reinfi\DependencyInjection\Service\AutoWiring\Factory\ResolverServiceFactory;
+use Reinfi\DependencyInjection\Service\AutoWiring\LazyResolverService;
+use Reinfi\DependencyInjection\Service\AutoWiring\Resolver\BuildInTypeWithDefaultResolver;
+use Reinfi\DependencyInjection\Service\AutoWiring\Resolver\ContainerInterfaceResolver;
+use Reinfi\DependencyInjection\Service\AutoWiring\Resolver\ContainerResolver;
+use Reinfi\DependencyInjection\Service\AutoWiring\Resolver\Factory\ContainerResolverFactory;
+use Reinfi\DependencyInjection\Service\AutoWiring\Resolver\Factory\PluginManagerResolverFactory;
+use Reinfi\DependencyInjection\Service\AutoWiring\Resolver\Factory\TranslatorResolverFactory;
+use Reinfi\DependencyInjection\Service\AutoWiring\Resolver\PluginManagerResolver;
+use Reinfi\DependencyInjection\Service\AutoWiring\Resolver\RequestResolver;
+use Reinfi\DependencyInjection\Service\AutoWiring\Resolver\ResponseResolver;
+use Reinfi\DependencyInjection\Service\AutoWiring\Resolver\TranslatorResolver;
+use Reinfi\DependencyInjection\Service\AutoWiring\ResolverService;
+use Reinfi\DependencyInjection\Service\AutoWiringService;
+use Reinfi\DependencyInjection\Service\CacheService;
+use Reinfi\DependencyInjection\Service\ConfigService;
+use Reinfi\DependencyInjection\Service\Extractor\AnnotationExtractor;
+use Reinfi\DependencyInjection\Service\Extractor\AttributeExtractor;
+use Reinfi\DependencyInjection\Service\Extractor\ExtractorInterface;
+use Reinfi\DependencyInjection\Service\Extractor\Factory\AnnotationExtractorFactory;
+use Reinfi\DependencyInjection\Service\Extractor\Factory\ExtractorFactory;
+use Reinfi\DependencyInjection\Service\Extractor\Factory\YamlExtractorFactory;
+use Reinfi\DependencyInjection\Service\Extractor\YamlExtractor;
+use Reinfi\DependencyInjection\Service\Factory\AutoWiringServiceFactory;
+use Reinfi\DependencyInjection\Service\Factory\CacheServiceFactory;
+use Reinfi\DependencyInjection\Service\Factory\ConfigServiceFactory;
+use Reinfi\DependencyInjection\Service\Factory\InjectionServiceFactory;
+use Reinfi\DependencyInjection\Service\InjectionService;
+
 return [
     'service_manager' => [
         'factories' => [
-            \Reinfi\DependencyInjection\Config\ModuleConfig::class => \Reinfi\DependencyInjection\Config\Factory\ModuleConfigFactory::class,
-            \Reinfi\DependencyInjection\Service\Extractor\AnnotationExtractor::class => \Reinfi\DependencyInjection\Service\Extractor\Factory\AnnotationExtractorFactory::class,
-            \Reinfi\DependencyInjection\Service\Extractor\AttributeExtractor::class => \Laminas\ServiceManager\Factory\InvokableFactory::class,
-            \Reinfi\DependencyInjection\Service\Extractor\YamlExtractor::class => \Reinfi\DependencyInjection\Service\Extractor\Factory\YamlExtractorFactory::class,
-            \Reinfi\DependencyInjection\Service\InjectionService::class => \Reinfi\DependencyInjection\Service\Factory\InjectionServiceFactory::class,
-            \Reinfi\DependencyInjection\Service\CacheService::class => \Reinfi\DependencyInjection\Service\Factory\CacheServiceFactory::class,
-            \Reinfi\DependencyInjection\Service\ConfigService::class => \Reinfi\DependencyInjection\Service\Factory\ConfigServiceFactory::class,
-            \Reinfi\DependencyInjection\Service\AutoWiringService::class => \Reinfi\DependencyInjection\Service\Factory\AutoWiringServiceFactory::class,
-            \Reinfi\DependencyInjection\Service\Extractor\ExtractorInterface::class => \Reinfi\DependencyInjection\Service\Extractor\Factory\ExtractorFactory::class,
-            \Reinfi\DependencyInjection\Service\AutoWiring\ResolverService::class => \Reinfi\DependencyInjection\Service\AutoWiring\Factory\ResolverServiceFactory::class,
-            \Reinfi\DependencyInjection\Service\AutoWiring\LazyResolverService::class => \Reinfi\DependencyInjection\Service\AutoWiring\Factory\LazyResolverServiceFactory::class,
-            \Reinfi\DependencyInjection\Service\AutoWiring\Resolver\ContainerResolver::class => \Reinfi\DependencyInjection\Service\AutoWiring\Resolver\Factory\ContainerResolverFactory::class,
-            \Reinfi\DependencyInjection\Service\AutoWiring\Resolver\ContainerInterfaceResolver::class => \Laminas\ServiceManager\Factory\InvokableFactory::class,
-            \Reinfi\DependencyInjection\Service\AutoWiring\Resolver\PluginManagerResolver::class => \Reinfi\DependencyInjection\Service\AutoWiring\Resolver\Factory\PluginManagerResolverFactory::class,
-            \Reinfi\DependencyInjection\Service\AutoWiring\Resolver\RequestResolver::class => \Laminas\ServiceManager\Factory\InvokableFactory::class,
-            \Reinfi\DependencyInjection\Service\AutoWiring\Resolver\ResponseResolver::class => \Laminas\ServiceManager\Factory\InvokableFactory::class,
-            \Reinfi\DependencyInjection\Service\AutoWiring\Resolver\TranslatorResolver::class => \Reinfi\DependencyInjection\Service\AutoWiring\Resolver\Factory\TranslatorResolverFactory::class,
-            \Reinfi\DependencyInjection\Service\AutoWiring\Resolver\BuildInTypeWithDefaultResolver::class => \Laminas\ServiceManager\Factory\InvokableFactory::class,
+            ModuleConfig::class => ModuleConfigFactory::class,
+            AnnotationExtractor::class => AnnotationExtractorFactory::class,
+            AttributeExtractor::class => InvokableFactory::class,
+            YamlExtractor::class => YamlExtractorFactory::class,
+            InjectionService::class => InjectionServiceFactory::class,
+            CacheService::class => CacheServiceFactory::class,
+            ConfigService::class => ConfigServiceFactory::class,
+            AutoWiringService::class => AutoWiringServiceFactory::class,
+            ExtractorInterface::class => ExtractorFactory::class,
+            ResolverService::class => ResolverServiceFactory::class,
+            LazyResolverService::class => LazyResolverServiceFactory::class,
+            ContainerResolver::class => ContainerResolverFactory::class,
+            ContainerInterfaceResolver::class => InvokableFactory::class,
+            PluginManagerResolver::class => PluginManagerResolverFactory::class,
+            RequestResolver::class => InvokableFactory::class,
+            ResponseResolver::class => InvokableFactory::class,
+            TranslatorResolver::class => TranslatorResolverFactory::class,
+            BuildInTypeWithDefaultResolver::class => InvokableFactory::class,
 
-            \Reinfi\DependencyInjection\Command\CacheWarmupCommand::class => \Laminas\ServiceManager\Factory\InvokableFactory::class,
+            CacheWarmupCommand::class => InvokableFactory::class,
         ],
-        'abstract_factories' => [
-            \Reinfi\DependencyInjection\AbstractFactory\Config\InjectConfigAbstractFactory::class,
-        ],
+        'abstract_factories' => [InjectConfigAbstractFactory::class],
     ],
 ];

--- a/ecs.php
+++ b/ecs.php
@@ -6,11 +6,11 @@ use Symplify\CodingStandard\Fixer\LineLength\LineLengthFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
 use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
 
-return static function (ECSConfig $configurator): void {
+return static function (ECSConfig $ecsConfig): void {
     // make ECS 16x faster
-    $configurator->parallel();
+    $ecsConfig->parallel();
 
-    $configurator->paths([
+    $ecsConfig->paths([
         __DIR__ . '/config/',
         __DIR__ . '/src/',
         __DIR__ . '/test/',
@@ -18,12 +18,12 @@ return static function (ECSConfig $configurator): void {
 
     // import SetList here in the end of ecs. is on purpose
     // to avoid overridden by existing Skip Option in current config
-    $configurator->import(SetList::PSR_12);
-    $configurator->import(SetList::COMMON);
-    $configurator->import(SetList::NAMESPACES);
-    $configurator->import(SetList::CLEAN_CODE);
+    $ecsConfig->import(SetList::PSR_12);
+    $ecsConfig->import(SetList::COMMON);
+    $ecsConfig->import(SetList::NAMESPACES);
+    $ecsConfig->import(SetList::CLEAN_CODE);
 
-    $configurator->rule(LineLengthFixer::class);
+    $ecsConfig->rule(LineLengthFixer::class);
 
-    $configurator->lineEnding("\n");
+    $ecsConfig->lineEnding("\n");
 };

--- a/rector.config.php
+++ b/rector.config.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector;
+use Rector\DeadCode\Rector\ClassMethod\RemoveEmptyClassMethodRector;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedConstructorParamRector;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPromotedPropertyRector;
+use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
+use Rector\Php84\Rector\Param\ExplicitNullableParamTypeRector;
+use Rector\PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitSelfCallRector;
+use Rector\PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitThisCallRector;
+use Rector\PHPUnit\CodeQuality\Rector\Class_\RemoveDataProviderParamKeysRector;
+use Rector\PHPUnit\Set\PHPUnitSetList;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__,
+    ])
+    ->withSkipPath(__DIR__ . '/src/Extension/Rector/Set/config')
+    ->withSkipPath('vendor')
+    ->withPhpSets()
+    ->withPreparedSets(
+        deadCode: true,
+        codeQuality: true,
+        codingStyle: true,
+        typeDeclarations: true,
+        privatization: true,
+        naming: true,
+        instanceOf: true,
+        earlyReturn: true,
+        strictBooleans: true,
+        rectorPreset: true,
+        phpunitCodeQuality: true,
+        doctrineCodeQuality: true,
+        symfonyCodeQuality: true,
+        symfonyConfigs: true,
+    )
+    ->withAttributesSets(
+        all: true,
+    )
+    ->withSets([
+        PHPUnitSetList::PHPUNIT_120,
+    ])
+    ->withImportNames(
+        removeUnusedImports: true,
+    )
+    ->withSkip([
+        PreferPHPUnitThisCallRector::class,
+        StringClassNameToClassConstantRector::class,
+    ])
+    ->withSkip([
+        RemoveDataProviderParamKeysRector::class => [__DIR__ . '/test'],
+        RemoveEmptyClassMethodRector::class => [ __DIR__ . '/test'],
+        RemoveUnusedConstructorParamRector::class => [__DIR__ . '/test'],
+        RemoveUnusedPromotedPropertyRector::class => [__DIR__ . '/test'],
+        RemoveUnusedVariableAssignRector::class => [__DIR__ . '/test'],
+    ])
+    ->withRules([
+        PreferPHPUnitSelfCallRector::class,
+        ExplicitNullableParamTypeRector::class,
+    ]);

--- a/src/AbstractFactory/Config/InjectConfigAbstractFactory.php
+++ b/src/AbstractFactory/Config/InjectConfigAbstractFactory.php
@@ -13,7 +13,7 @@ use Reinfi\DependencyInjection\Service\ConfigService;
  */
 class InjectConfigAbstractFactory implements AbstractFactoryInterface
 {
-    private const MATCH_PATTERN = '/^Config\.(.*)$/';
+    private const string MATCH_PATTERN = '/^Config\.(.*)$/';
 
     private array $matches = [];
 

--- a/src/Annotation/InjectConfig.php
+++ b/src/Annotation/InjectConfig.php
@@ -23,7 +23,7 @@ final class InjectConfig extends AbstractAnnotation
 
     public function __construct(array $values)
     {
-        $this->asArray = isset($values['asArray']) ? (bool) $values['asArray'] : false;
+        $this->asArray = isset($values['asArray']) && (bool) $values['asArray'];
         $this->configPath = $values['value'];
     }
 

--- a/src/Attribute/AbstractInjectPluginManager.php
+++ b/src/Attribute/AbstractInjectPluginManager.php
@@ -15,14 +15,10 @@ abstract class AbstractInjectPluginManager extends AbstractAttribute
 {
     public const string PLUGIN_MANAGER = '';
 
-    private string $name;
-
-    private ?array $options;
-
-    public function __construct(string $name, ?array $options = null)
-    {
-        $this->name = $name;
-        $this->options = $options;
+    public function __construct(
+        private readonly string $name,
+        private readonly ?array $options = null
+    ) {
     }
 
     public function __invoke(ContainerInterface $container): mixed

--- a/src/Attribute/Inject.php
+++ b/src/Attribute/Inject.php
@@ -12,10 +12,10 @@ use Reinfi\DependencyInjection\Injection\InjectionInterface;
  * @package Reinfi\DependencyInjection\Attribute
  */
 #[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
-final class Inject implements InjectionInterface
+final readonly class Inject implements InjectionInterface
 {
     public function __construct(
-        public readonly string $value
+        public string $value
     ) {
     }
 

--- a/src/Attribute/InjectConstant.php
+++ b/src/Attribute/InjectConstant.php
@@ -12,10 +12,10 @@ use Reinfi\DependencyInjection\Injection\InjectionInterface;
  * @package Reinfi\DependencyInjection\Attribute
  */
 #[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
-final class InjectConstant implements InjectionInterface
+final readonly class InjectConstant implements InjectionInterface
 {
     public function __construct(
-        private readonly string $value
+        private string $value
     ) {
     }
 

--- a/src/Attribute/InjectContainer.php
+++ b/src/Attribute/InjectContainer.php
@@ -14,10 +14,6 @@ use Reinfi\DependencyInjection\Injection\InjectionInterface;
 #[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 final class InjectContainer implements InjectionInterface
 {
-    public function __construct()
-    {
-    }
-
     public function __invoke(ContainerInterface $container): ContainerInterface
     {
         return $container;

--- a/src/Attribute/InjectParent.php
+++ b/src/Attribute/InjectParent.php
@@ -13,10 +13,10 @@ use Reinfi\DependencyInjection\Injection\InjectionInterface;
  * @package Reinfi\DependencyInjection\Attribute
  */
 #[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
-final class InjectParent implements InjectionInterface
+final readonly class InjectParent implements InjectionInterface
 {
     public function __construct(
-        private readonly string $value
+        private string $value
     ) {
     }
 

--- a/src/Command/CacheWarmupCommand.php
+++ b/src/Command/CacheWarmupCommand.php
@@ -52,16 +52,16 @@ class CacheWarmupCommand extends Command
             throw new InvalidArgumentException(sprintf('Invalid config path: %s', $config));
         }
 
-        $container = Application::init(include $path)
+        $serviceManager = Application::init(include $path)
             ->getServiceManager();
 
-        $serviceManagerConfig = $this->getServiceManagerConfig($container);
+        $serviceManagerConfig = $this->getServiceManagerConfig($serviceManager);
 
         $this->warmupConfig(
             $serviceManagerConfig['factories'] ?? [],
-            $container->get(ExtractorInterface::class),
-            $container->get(ResolverService::class),
-            $container->get(CacheService::class)
+            $serviceManager->get(ExtractorInterface::class),
+            $serviceManager->get(ResolverService::class),
+            $serviceManager->get(CacheService::class)
         );
 
         $output->writeln('Finished cache warmup');

--- a/src/Exception/AutoWiringNotPossibleException.php
+++ b/src/Exception/AutoWiringNotPossibleException.php
@@ -15,38 +15,38 @@ use ReflectionParameter;
  */
 class AutoWiringNotPossibleException extends Exception
 {
-    public static function fromClassName(string $className, ?ReflectionClass $constructedClass): self
+    public static function fromClassName(string $className, ?ReflectionClass $reflectionClass): self
     {
         return new self(
             sprintf(
                 'Could not resolve class %s to inject into class %s',
                 $className,
-                $constructedClass === null ? '<unknown>' : $constructedClass->getName()
+                $reflectionClass instanceof ReflectionClass ? $reflectionClass->getName() : '<unknown>'
             )
         );
     }
 
-    public static function fromMissingTypeHint(ReflectionParameter $reflParameter): self
+    public static function fromMissingTypeHint(ReflectionParameter $reflectionParameter): self
     {
-        $declaringClass = $reflParameter->getDeclaringClass();
+        $declaringClass = $reflectionParameter->getDeclaringClass();
 
         return new self(
             sprintf(
                 'Could not resolve variable %s as it is missing a typehint to inject into class %s',
-                $reflParameter->getName(),
+                $reflectionParameter->getName(),
                 $declaringClass === null ? '<unknown>' : $declaringClass->getName()
             )
         );
     }
 
-    public static function fromBuildInType(ReflectionParameter $reflParameter): self
+    public static function fromBuildInType(ReflectionParameter $reflectionParameter): self
     {
-        $declaringClass = $reflParameter->getDeclaringClass();
+        $declaringClass = $reflectionParameter->getDeclaringClass();
 
         return new self(
             sprintf(
                 'Could not resolve variable %s as it is of a buildin type to inject into class %s',
-                $reflParameter->getName(),
+                $reflectionParameter->getName(),
                 $declaringClass === null ? '<unknown>' : $declaringClass->getName()
             )
         );

--- a/src/Extension/PHPStan/Resolve/AutoWiringClassesResolver.php
+++ b/src/Extension/PHPStan/Resolve/AutoWiringClassesResolver.php
@@ -5,21 +5,20 @@ declare(strict_types=1);
 namespace Reinfi\DependencyInjection\Extension\PHPStan\Resolve;
 
 use Laminas\Config\Config;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 use Reinfi\DependencyInjection\Extension\PHPStan\ServiceManagerLoader;
 use Reinfi\DependencyInjection\Factory\AutoWiringFactory;
 
 class AutoWiringClassesResolver
 {
-    private ServiceManagerLoader $serviceManagerLoader;
-
     /**
      * @var string[]|null
      */
     private ?array $autowiredClasses = null;
 
-    public function __construct(ServiceManagerLoader $serviceManagerLoader)
-    {
-        $this->serviceManagerLoader = $serviceManagerLoader;
+    public function __construct(
+        private readonly ServiceManagerLoader $serviceManagerLoader
+    ) {
     }
 
     public function isAutowired(string $className): bool
@@ -38,7 +37,7 @@ class AutoWiringClassesResolver
     {
         $serviceManager = $this->serviceManagerLoader->getServiceLocator();
 
-        if ($serviceManager === null) {
+        if (! $serviceManager instanceof ServiceLocatorInterface) {
             return [];
         }
 
@@ -66,9 +65,7 @@ class AutoWiringClassesResolver
 
                 $autowiredClasses = array_filter(
                     $factories,
-                    function ($factoryClass): bool {
-                        return $factoryClass === AutoWiringFactory::class;
-                    }
+                    fn ($factoryClass): bool => $factoryClass === AutoWiringFactory::class
                 );
 
                 return array_merge($classes, array_keys($autowiredClasses));

--- a/src/Extension/PHPStan/Resolve/AutoWiringPossibleResolver.php
+++ b/src/Extension/PHPStan/Resolve/AutoWiringPossibleResolver.php
@@ -4,24 +4,23 @@ declare(strict_types=1);
 
 namespace Reinfi\DependencyInjection\Extension\PHPStan\Resolve;
 
+use Laminas\ServiceManager\ServiceLocatorInterface;
 use Reinfi\DependencyInjection\Extension\PHPStan\ServiceManagerLoader;
 use Reinfi\DependencyInjection\Service\AutoWiring\ResolverService;
 use Reinfi\DependencyInjection\Service\AutoWiring\ResolverServiceInterface;
 
 class AutoWiringPossibleResolver
 {
-    private ServiceManagerLoader $serviceManagerLoader;
-
-    public function __construct(ServiceManagerLoader $serviceManagerLoader)
-    {
-        $this->serviceManagerLoader = $serviceManagerLoader;
+    public function __construct(
+        private readonly ServiceManagerLoader $serviceManagerLoader
+    ) {
     }
 
     public function resolve(string $className): void
     {
         $resolverService = $this->getResolverService();
 
-        if ($resolverService === null) {
+        if (! $resolverService instanceof ResolverServiceInterface) {
             return;
         }
 
@@ -32,7 +31,7 @@ class AutoWiringPossibleResolver
     {
         $serviceLocator = $this->serviceManagerLoader->getServiceLocator();
 
-        if ($serviceLocator === null) {
+        if (! $serviceLocator instanceof ServiceLocatorInterface) {
             return null;
         }
 

--- a/src/Extension/PHPStan/ServiceManagerLoader.php
+++ b/src/Extension/PHPStan/ServiceManagerLoader.php
@@ -10,7 +10,7 @@ use PHPStan\ShouldNotHappenException;
 
 final class ServiceManagerLoader
 {
-    private ?ServiceManager $serviceLocator = null;
+    private ?ServiceManager $serviceManager = null;
 
     public function __construct(?string $serviceManagerLoader)
     {
@@ -30,11 +30,11 @@ final class ServiceManagerLoader
             ));
         }
 
-        $this->serviceLocator = $serviceManager;
+        $this->serviceManager = $serviceManager;
     }
 
     public function getServiceLocator(): ?ServiceLocatorInterface
     {
-        return $this->serviceLocator;
+        return $this->serviceManager;
     }
 }

--- a/src/Factory/AbstractFactory.php
+++ b/src/Factory/AbstractFactory.php
@@ -36,7 +36,7 @@ abstract class AbstractFactory implements FactoryInterface
         throw new InvalidServiceException(
             sprintf(
                 '%s requires that the requested name is provided on invocation; please update your tests or consuming container',
-                __CLASS__
+                self::class
             )
         );
     }

--- a/src/Injection/AutoWiring.php
+++ b/src/Injection/AutoWiring.php
@@ -13,11 +13,9 @@ use Reinfi\DependencyInjection\Exception\AutoWiringNotPossibleException;
  */
 class AutoWiring implements InjectionInterface
 {
-    private string $serviceName;
-
-    public function __construct(string $serviceName)
-    {
-        $this->serviceName = $serviceName;
+    public function __construct(
+        private readonly string $serviceName
+    ) {
     }
 
     /**
@@ -29,10 +27,8 @@ class AutoWiring implements InjectionInterface
             return $container->get($this->serviceName);
         }
 
-        if ($container instanceof AbstractPluginManager) {
-            if ($container->getServiceLocator()->has($this->serviceName)) {
-                return $container->getServiceLocator()->get($this->serviceName);
-            }
+        if ($container instanceof AbstractPluginManager && $container->getServiceLocator()->has($this->serviceName)) {
+            return $container->getServiceLocator()->get($this->serviceName);
         }
 
         throw new AutoWiringNotPossibleException($this->serviceName);

--- a/src/Injection/AutoWiringPluginManager.php
+++ b/src/Injection/AutoWiringPluginManager.php
@@ -13,14 +13,10 @@ use Reinfi\DependencyInjection\Exception\AutoWiringNotPossibleException;
  */
 class AutoWiringPluginManager implements InjectionInterface
 {
-    private string $pluginManager;
-
-    private string $serviceName;
-
-    public function __construct(string $pluginManager, string $serviceName)
-    {
-        $this->pluginManager = $pluginManager;
-        $this->serviceName = $serviceName;
+    public function __construct(
+        private readonly string $pluginManager,
+        private readonly string $serviceName
+    ) {
     }
 
     /**

--- a/src/Service/AutoWiring/Factory/ResolverServiceFactory.php
+++ b/src/Service/AutoWiring/Factory/ResolverServiceFactory.php
@@ -28,7 +28,7 @@ class ResolverServiceFactory
         $resolverStackConfig = $this->getResolverStack($config);
 
         /** @var ResolverInterface[] $resolverStack */
-        $resolverStack = array_map([$container, 'get'], $resolverStackConfig);
+        $resolverStack = array_map($container->get(...), $resolverStackConfig);
 
         return new ResolverService($resolverStack);
     }

--- a/src/Service/AutoWiring/Resolver/BuildInTypeWithDefaultResolver.php
+++ b/src/Service/AutoWiring/Resolver/BuildInTypeWithDefaultResolver.php
@@ -14,9 +14,9 @@ use Reinfi\DependencyInjection\Injection\Value;
  */
 class BuildInTypeWithDefaultResolver implements ResolverInterface
 {
-    public function resolve(ReflectionParameter $parameter): ?InjectionInterface
+    public function resolve(ReflectionParameter $reflectionParameter): ?InjectionInterface
     {
-        $type = $parameter->getType();
+        $type = $reflectionParameter->getType();
         if (! $type instanceof ReflectionNamedType) {
             return null;
         }
@@ -25,10 +25,10 @@ class BuildInTypeWithDefaultResolver implements ResolverInterface
             return null;
         }
 
-        if (! $parameter->isDefaultValueAvailable()) {
+        if (! $reflectionParameter->isDefaultValueAvailable()) {
             return null;
         }
 
-        return new Value($parameter->getDefaultValue());
+        return new Value($reflectionParameter->getDefaultValue());
     }
 }

--- a/src/Service/AutoWiring/Resolver/ContainerInterfaceResolver.php
+++ b/src/Service/AutoWiring/Resolver/ContainerInterfaceResolver.php
@@ -17,9 +17,9 @@ use Reinfi\DependencyInjection\Injection\InjectionInterface;
  */
 class ContainerInterfaceResolver implements ResolverInterface
 {
-    public function resolve(ReflectionParameter $parameter): ?InjectionInterface
+    public function resolve(ReflectionParameter $reflectionParameter): ?InjectionInterface
     {
-        $type = $parameter->getType();
+        $type = $reflectionParameter->getType();
         if (! $type instanceof ReflectionNamedType) {
             return null;
         }

--- a/src/Service/AutoWiring/Resolver/ContainerResolver.php
+++ b/src/Service/AutoWiring/Resolver/ContainerResolver.php
@@ -20,9 +20,9 @@ class ContainerResolver implements ResolverInterface
     ) {
     }
 
-    public function resolve(ReflectionParameter $parameter): ?InjectionInterface
+    public function resolve(ReflectionParameter $reflectionParameter): ?InjectionInterface
     {
-        $type = $parameter->getType();
+        $type = $reflectionParameter->getType();
         if (! $type instanceof ReflectionNamedType) {
             return null;
         }

--- a/src/Service/AutoWiring/Resolver/PluginManagerResolver.php
+++ b/src/Service/AutoWiring/Resolver/PluginManagerResolver.php
@@ -34,9 +34,9 @@ class PluginManagerResolver implements ResolverInterface
     ) {
     }
 
-    public function resolve(ReflectionParameter $parameter): ?InjectionInterface
+    public function resolve(ReflectionParameter $reflectionParameter): ?InjectionInterface
     {
-        $type = $parameter->getType();
+        $type = $reflectionParameter->getType();
         if (! $type instanceof ReflectionNamedType) {
             return null;
         }

--- a/src/Service/AutoWiring/Resolver/RequestResolver.php
+++ b/src/Service/AutoWiring/Resolver/RequestResolver.php
@@ -16,9 +16,9 @@ use Reinfi\DependencyInjection\Injection\InjectionInterface;
  */
 class RequestResolver implements ResolverInterface
 {
-    public function resolve(ReflectionParameter $parameter): ?InjectionInterface
+    public function resolve(ReflectionParameter $reflectionParameter): ?InjectionInterface
     {
-        $type = $parameter->getType();
+        $type = $reflectionParameter->getType();
         if (! $type instanceof ReflectionNamedType) {
             return null;
         }

--- a/src/Service/AutoWiring/Resolver/ResolverInterface.php
+++ b/src/Service/AutoWiring/Resolver/ResolverInterface.php
@@ -12,5 +12,5 @@ use Reinfi\DependencyInjection\Injection\InjectionInterface;
  */
 interface ResolverInterface
 {
-    public function resolve(ReflectionParameter $parameter): ?InjectionInterface;
+    public function resolve(ReflectionParameter $reflectionParameter): ?InjectionInterface;
 }

--- a/src/Service/AutoWiring/Resolver/ResponseResolver.php
+++ b/src/Service/AutoWiring/Resolver/ResponseResolver.php
@@ -16,9 +16,9 @@ use Reinfi\DependencyInjection\Injection\InjectionInterface;
  */
 class ResponseResolver implements ResolverInterface
 {
-    public function resolve(ReflectionParameter $parameter): ?InjectionInterface
+    public function resolve(ReflectionParameter $reflectionParameter): ?InjectionInterface
     {
-        $type = $parameter->getType();
+        $type = $reflectionParameter->getType();
         if (! $type instanceof ReflectionNamedType) {
             return null;
         }

--- a/src/Service/AutoWiring/Resolver/TranslatorResolver.php
+++ b/src/Service/AutoWiring/Resolver/TranslatorResolver.php
@@ -19,17 +19,17 @@ class TranslatorResolver implements ResolverInterface
     /**
      * used to avoid requirement of laminas/laminas-i18n module, deprecated interface name.
      */
-    private const TRANSLATOR_INTERFACE_OLD = 'Laminas\I18n\Translator\TranslatorInterface';
+    private const string TRANSLATOR_INTERFACE_OLD = 'Laminas\I18n\Translator\TranslatorInterface';
 
     /**
      * used to avoid requirement of laminas/laminas-translator module.
      */
-    private const TRANSLATOR_INTERFACE = 'Laminas\Translator\TranslatorInterface';
+    private const string TRANSLATOR_INTERFACE = 'Laminas\Translator\TranslatorInterface';
 
     /**
      * possible names for translator service within container
      */
-    private const TRANSLATOR_CONTAINER_SERVICE_NAME = [
+    private const array TRANSLATOR_CONTAINER_SERVICE_NAME = [
         self::TRANSLATOR_INTERFACE,
         'MvcTranslator',
         self::TRANSLATOR_INTERFACE_OLD,
@@ -41,9 +41,9 @@ class TranslatorResolver implements ResolverInterface
     ) {
     }
 
-    public function resolve(ReflectionParameter $parameter): ?InjectionInterface
+    public function resolve(ReflectionParameter $reflectionParameter): ?InjectionInterface
     {
-        if (! $this->isValid($parameter)) {
+        if (! $this->isValid($reflectionParameter)) {
             return null;
         }
 
@@ -56,9 +56,9 @@ class TranslatorResolver implements ResolverInterface
         return null;
     }
 
-    private function isValid(ReflectionParameter $parameter): bool
+    private function isValid(ReflectionParameter $reflectionParameter): bool
     {
-        $type = $parameter->getType();
+        $type = $reflectionParameter->getType();
         if (! $type instanceof ReflectionNamedType) {
             return false;
         }
@@ -72,11 +72,18 @@ class TranslatorResolver implements ResolverInterface
 
         $reflectionClass = new ReflectionClass($type->getName());
         $interfaceNames = $reflectionClass->getInterfaceNames();
+        if ($reflectionClass->getName() === self::TRANSLATOR_INTERFACE_OLD) {
+            return true;
+        }
 
-        return $reflectionClass->getName() === self::TRANSLATOR_INTERFACE_OLD
-            || in_array(self::TRANSLATOR_INTERFACE_OLD, $interfaceNames, true)
-            || $reflectionClass->getName() === self::TRANSLATOR_INTERFACE
-            || in_array(self::TRANSLATOR_INTERFACE, $interfaceNames, true)
-        ;
+        if (in_array(self::TRANSLATOR_INTERFACE_OLD, $interfaceNames, true)) {
+            return true;
+        }
+
+        if ($reflectionClass->getName() === self::TRANSLATOR_INTERFACE) {
+            return true;
+        }
+
+        return in_array(self::TRANSLATOR_INTERFACE, $interfaceNames, true);
     }
 }

--- a/src/Service/AutoWiringService.php
+++ b/src/Service/AutoWiringService.php
@@ -18,7 +18,7 @@ class AutoWiringService
 
     public function __construct(
         private readonly ResolverServiceInterface $resolverService,
-        private readonly CacheService $cache
+        private readonly CacheService $cacheService
     ) {
     }
 
@@ -32,7 +32,7 @@ class AutoWiringService
     ): ?array {
         $injections = $this->getInjections($className, $options);
 
-        if (count($injections) === 0 && $options === null) {
+        if ($injections === [] && $options === null) {
             return null;
         }
 
@@ -50,8 +50,8 @@ class AutoWiringService
     {
         $cacheKey = $this->buildCacheKey($className);
 
-        if ($options === null && $this->cache->has($cacheKey)) {
-            $cachedItem = $this->cache->get($cacheKey);
+        if ($options === null && $this->cacheService->has($cacheKey)) {
+            $cachedItem = $this->cacheService->get($cacheKey);
 
             if (is_array($cachedItem)) {
                 // @phpstan-ignore-next-line
@@ -62,7 +62,7 @@ class AutoWiringService
         $injections = $this->resolverService->resolve($className, $options);
 
         if ($options === null) {
-            $this->cache->set($cacheKey, $injections);
+            $this->cacheService->set($cacheKey, $injections);
         }
 
         return $injections;

--- a/src/Service/ConfigService.php
+++ b/src/Service/ConfigService.php
@@ -24,7 +24,7 @@ class ConfigService
     {
         $nullAllowed = true;
 
-        if (substr($configPath, -1) === '!') {
+        if (str_ends_with($configPath, '!')) {
             $nullAllowed = false;
             $configPath = substr($configPath, 0, -1);
         }
@@ -54,7 +54,7 @@ class ConfigService
             throw new ConfigPathNotFoundException($currentKey);
         }
 
-        if (count($configParts) === 0) {
+        if ($configParts === []) {
             return $config[$currentKey];
         }
 
@@ -63,6 +63,7 @@ class ConfigService
             if ($nullAllowed) {
                 return null;
             }
+
             throw new ConfigPathNotFoundException($currentKey);
         }
 

--- a/src/Service/Extractor/AnnotationExtractor.php
+++ b/src/Service/Extractor/AnnotationExtractor.php
@@ -16,18 +16,18 @@ use Reinfi\DependencyInjection\Annotation\AnnotationInterface;
 class AnnotationExtractor implements ExtractorInterface
 {
     public function __construct(
-        private readonly AnnotationReader $reader
+        private readonly AnnotationReader $annotationReader
     ) {
     }
 
     public function getPropertiesInjections(string $className): array
     {
         $injections = [];
-        $reflection = new ReflectionClass($className);
-        foreach ($reflection->getProperties() as $index => $property) {
+        $reflectionClass = new ReflectionClass($className);
+        foreach ($reflectionClass->getProperties() as $index => $property) {
             $reflectionProperty = new ReflectionProperty($className, $property->getName());
 
-            $inject = $this->reader->getPropertyAnnotation($reflectionProperty, AnnotationInterface::class);
+            $inject = $this->annotationReader->getPropertyAnnotation($reflectionProperty, AnnotationInterface::class);
 
             if ($inject !== null) {
                 $injections[$index] = $inject;
@@ -43,13 +43,8 @@ class AnnotationExtractor implements ExtractorInterface
             return [];
         }
 
-        $injections = $this->reader->getMethodAnnotations(new ReflectionMethod($className, '__construct'));
+        $injections = $this->annotationReader->getMethodAnnotations(new ReflectionMethod($className, '__construct'));
 
-        return array_filter(
-            $injections,
-            function ($annotation) {
-                return $annotation instanceof AnnotationInterface;
-            }
-        );
+        return array_filter($injections, fn ($annotation): bool => $annotation instanceof AnnotationInterface);
     }
 }

--- a/src/Service/Extractor/AttributeExtractor.php
+++ b/src/Service/Extractor/AttributeExtractor.php
@@ -14,8 +14,8 @@ class AttributeExtractor implements ExtractorInterface
     public function getPropertiesInjections(string $className): array
     {
         $injections = [];
-        $reflection = new ReflectionClass($className);
-        foreach ($reflection->getProperties() as $index => $property) {
+        $reflectionClass = new ReflectionClass($className);
+        foreach ($reflectionClass->getProperties() as $index => $property) {
             $reflectionProperty = new ReflectionProperty($className, $property->getName());
 
             $attributes = $reflectionProperty->getAttributes();
@@ -39,9 +39,9 @@ class AttributeExtractor implements ExtractorInterface
     public function getConstructorInjections(string $className): array
     {
         $injections = [];
-        $reflection = new ReflectionClass($className);
+        $reflectionClass = new ReflectionClass($className);
 
-        $reflectionConstructor = $reflection->getConstructor();
+        $reflectionConstructor = $reflectionClass->getConstructor();
 
         if ($reflectionConstructor === null) {
             return $injections;
@@ -61,14 +61,14 @@ class AttributeExtractor implements ExtractorInterface
         return $injections;
     }
 
-    private function getInjectionFromAttribute(ReflectionAttribute $attribute): ?InjectionInterface
+    private function getInjectionFromAttribute(ReflectionAttribute $reflectionAttribute): ?InjectionInterface
     {
-        $attributeName = $attribute->getName();
+        $attributeName = $reflectionAttribute->getName();
         if (! is_subclass_of($attributeName, InjectionInterface::class)) {
             return null;
         }
 
-        $instance = $attribute->newInstance();
+        $instance = $reflectionAttribute->newInstance();
         if (! $instance instanceof InjectionInterface) {
             return null;
         }

--- a/src/Service/Extractor/ExtractorChain.php
+++ b/src/Service/Extractor/ExtractorChain.php
@@ -24,7 +24,7 @@ class ExtractorChain implements ExtractorInterface
         return array_reduce(
             $this->chain,
             function (array $injections, ExtractorInterface $extractor) use ($className): array {
-                if (count($injections) > 0) {
+                if ($injections !== []) {
                     return $injections;
                 }
 
@@ -42,7 +42,7 @@ class ExtractorChain implements ExtractorInterface
         return array_reduce(
             $this->chain,
             function (array $injections, ExtractorInterface $extractor) use ($className): array {
-                if (count($injections) > 0) {
+                if ($injections !== []) {
                     return $injections;
                 }
 

--- a/src/Service/Extractor/Factory/YamlExtractorFactory.php
+++ b/src/Service/Extractor/Factory/YamlExtractorFactory.php
@@ -24,8 +24,8 @@ class YamlExtractorFactory
         /** @var array $config */
         $config = $container->get(ModuleConfig::class);
 
-        $reflClass = new ReflectionClass(AnnotationInterface::class);
+        $reflectionClass = new ReflectionClass(AnnotationInterface::class);
 
-        return new YamlExtractor($yaml, $config['extractor_options']['file'], $reflClass->getNamespaceName());
+        return new YamlExtractor($yaml, $config['extractor_options']['file'], $reflectionClass->getNamespaceName());
     }
 }

--- a/src/Service/Extractor/YamlExtractor.php
+++ b/src/Service/Extractor/YamlExtractor.php
@@ -6,6 +6,7 @@ namespace Reinfi\DependencyInjection\Service\Extractor;
 
 use InvalidArgumentException;
 use ReflectionClass;
+use ReflectionMethod;
 use Reinfi\DependencyInjection\Exception\InjectionTypeUnknownException;
 use Reinfi\DependencyInjection\Injection\InjectionInterface;
 use RuntimeException;
@@ -35,7 +36,7 @@ class YamlExtractor implements ExtractorInterface
     {
         $config = $this->getConfig($className);
 
-        if (count($config) === 0) {
+        if ($config === []) {
             return [];
         }
 
@@ -84,11 +85,11 @@ class YamlExtractor implements ExtractorInterface
         }
 
         $reflectionClass = new ReflectionClass($injectionClass);
-        if ($reflectionClass->getConstructor() !== null) {
+        if ($reflectionClass->getConstructor() instanceof ReflectionMethod) {
             $injection = $reflectionClass->newInstance($spec);
 
             if (! $injection instanceof InjectionInterface) {
-                throw new InjectionTypeUnknownException('Invalid class of type ' . get_class($injection));
+                throw new InjectionTypeUnknownException('Invalid class of type ' . $injection::class);
             }
 
             return $injection;
@@ -97,7 +98,7 @@ class YamlExtractor implements ExtractorInterface
         $injection = new $injectionClass();
 
         if (! $injection instanceof InjectionInterface) {
-            throw new InjectionTypeUnknownException('Invalid class of type ' . get_class($injection));
+            throw new InjectionTypeUnknownException('Invalid class of type ' . $injection::class);
         }
 
         foreach ($spec as $key => $value) {

--- a/src/Service/InjectionService.php
+++ b/src/Service/InjectionService.php
@@ -18,7 +18,7 @@ class InjectionService
 
     public function __construct(
         private readonly ExtractorInterface $extractor,
-        private readonly CacheService $cache
+        private readonly CacheService $cacheService
     ) {
     }
 
@@ -31,7 +31,7 @@ class InjectionService
     {
         $injections = $this->getInjections($className);
 
-        if (count($injections) === 0) {
+        if ($injections === []) {
             return false;
         }
 
@@ -51,8 +51,8 @@ class InjectionService
     {
         $cacheKey = $this->buildCacheKey($className);
 
-        if ($this->cache->has($cacheKey)) {
-            $cachedItem = $this->cache->get($cacheKey);
+        if ($this->cacheService->has($cacheKey)) {
+            $cachedItem = $this->cacheService->get($cacheKey);
 
             if (is_array($cachedItem)) {
                 // @phpstan-ignore-next-line
@@ -64,7 +64,7 @@ class InjectionService
             $this->extractor->getPropertiesInjections($className),
             $this->extractor->getConstructorInjections($className)
         );
-        $this->cache->set($cacheKey, $injections);
+        $this->cacheService->set($cacheKey, $injections);
 
         return $injections;
     }

--- a/src/Traits/WarmupTrait.php
+++ b/src/Traits/WarmupTrait.php
@@ -21,18 +21,19 @@ trait WarmupTrait
         array $factoriesConfig,
         ExtractorInterface $extractor,
         ResolverServiceInterface $resolverService,
-        CacheService $cache
-    ) {
+        CacheService $cacheService
+    ): void {
         array_walk(
             $factoriesConfig,
-            function ($factoryClass, $className) use ($extractor, $resolverService, $cache) {
+            function ($factoryClass, $className) use ($extractor, $resolverService, $cacheService): void {
                 if (! is_string($factoryClass)) {
                     return;
                 }
+
                 $injections = $this->handleService($className, $factoryClass, $extractor, $resolverService);
 
                 if (count($injections) > 0) {
-                    $cache->set($this->buildCacheKey($className), $injections);
+                    $cacheService->set($this->buildCacheKey($className), $injections);
                 }
             }
         );
@@ -63,7 +64,7 @@ trait WarmupTrait
         );
     }
 
-    private function warmupAutoWiring(ResolverServiceInterface $resolverService, string $className)
+    private function warmupAutoWiring(ResolverServiceInterface $resolverService, string $className): array
     {
         return $resolverService->resolve($className);
     }

--- a/test/Integration/Command/CacheWarmupCommandTest.php
+++ b/test/Integration/Command/CacheWarmupCommandTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Reinfi\DependencyInjection\Test\Integration\Command;
 
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Reinfi\DependencyInjection\Annotation\Inject;
 use Reinfi\DependencyInjection\Annotation\InjectConfig;
@@ -15,10 +16,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * @package Reinfi\DependencyInjection\Test\Integration\Command
- *
- * @group integration
  */
-class CacheWarmupCommandTest extends TestCase
+#[Group('integration')]
+final class CacheWarmupCommandTest extends TestCase
 {
     protected function setUp(): void
     {
@@ -33,7 +33,7 @@ class CacheWarmupCommandTest extends TestCase
     {
         $config = __DIR__ . '/../../resources/application_config.php';
 
-        $input = new ArgvInput(
+        $argvInput = new ArgvInput(
             [
                 'command' => 'reinfi:di:cache',
                 'applicationConfig' => $config,
@@ -44,8 +44,8 @@ class CacheWarmupCommandTest extends TestCase
             ->method('writeln')
             ->with($this->isString());
 
-        $command = new CacheWarmupCommand();
-        $command->run($input, $output);
+        $cacheWarmupCommand = new CacheWarmupCommand();
+        $cacheWarmupCommand->run($argvInput, $output);
     }
 
     public function testItThrowsExceptionIfPathNotValid(): void
@@ -54,7 +54,7 @@ class CacheWarmupCommandTest extends TestCase
 
         $config = __DIR__ . '/../resources/application_config.php';
 
-        $input = new ArgvInput(
+        $argvInput = new ArgvInput(
             [
                 'command' => 'reinfi:di:cache',
                 'applicationConfig' => $config,
@@ -62,7 +62,7 @@ class CacheWarmupCommandTest extends TestCase
         );
         $output = $this->createMock(OutputInterface::class);
 
-        $command = new CacheWarmupCommand();
-        $command->run($input, $output);
+        $cacheWarmupCommand = new CacheWarmupCommand();
+        $cacheWarmupCommand->run($argvInput, $output);
     }
 }

--- a/test/Integration/Factory/AutoWiringFactoryTest.php
+++ b/test/Integration/Factory/AutoWiringFactoryTest.php
@@ -6,6 +6,7 @@ namespace Reinfi\DependencyInjection\Test\Integration\Factory;
 
 use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
+use PHPUnit\Framework\Attributes\Group;
 use Reinfi\DependencyInjection\Factory\AutoWiringFactory;
 use Reinfi\DependencyInjection\Test\Base\AbstractIntegration;
 use Reinfi\DependencyInjection\Test\Service\PluginService;
@@ -18,52 +19,51 @@ use Reinfi\DependencyInjection\Test\Service\ServiceContainer;
 
 /**
  * @package Reinfi\DependencyInjection\Test\Integration\Factory
- *
- * @group integration
  */
-class AutoWiringFactoryTest extends AbstractIntegration
+#[Group('integration')]
+final class AutoWiringFactoryTest extends AbstractIntegration
 {
     public function testItCreatesServiceWithDependencies(): void
     {
-        $container = $this->getServiceManager(require __DIR__ . '/../../resources/config.php');
+        $serviceManager = $this->getServiceManager(require __DIR__ . '/../../resources/config.php');
 
         $factory = new AutoWiringFactory();
 
-        $instance = $factory->createService($container, Service1::class, Service1::class);
+        $instance = $factory->createService($serviceManager, Service1::class, Service1::class);
 
         self::assertInstanceOf(Service1::class, $instance);
     }
 
     public function testItCreatesServiceWithContainerAsDependency(): void
     {
-        $container = $this->getServiceManager(require __DIR__ . '/../../resources/config.php');
+        $serviceManager = $this->getServiceManager(require __DIR__ . '/../../resources/config.php');
 
         $factory = new AutoWiringFactory();
 
-        $instance = $factory->createService($container, ServiceContainer::class, ServiceContainer::class);
+        $instance = $factory->createService($serviceManager, ServiceContainer::class, ServiceContainer::class);
 
         self::assertInstanceOf(ServiceContainer::class, $instance);
     }
 
     public function testItCreatesServiceWithNoDependencies(): void
     {
-        $container = $this->getServiceManager(require __DIR__ . '/../../resources/config.php');
+        $serviceManager = $this->getServiceManager(require __DIR__ . '/../../resources/config.php');
 
         $factory = new AutoWiringFactory();
 
-        $instance = $factory->createService($container, Service3::class, Service3::class);
+        $instance = $factory->createService($serviceManager, Service3::class, Service3::class);
 
         self::assertInstanceOf(Service3::class, $instance);
     }
 
     public function testItCreatesServiceWithBuiltInType(): void
     {
-        $container = $this->getServiceManager(require __DIR__ . '/../../resources/config.php');
+        $serviceManager = $this->getServiceManager(require __DIR__ . '/../../resources/config.php');
 
         $factory = new AutoWiringFactory();
 
         $instance = $factory->createService(
-            $container,
+            $serviceManager,
             ServiceBuildInTypeWithDefault::class,
             ServiceBuildInTypeWithDefault::class
         );
@@ -73,12 +73,12 @@ class AutoWiringFactoryTest extends AbstractIntegration
 
     public function testItCreatesServiceWithBuiltInTypeUsingConstantAsDefault(): void
     {
-        $container = $this->getServiceManager(require __DIR__ . '/../../resources/config.php');
+        $serviceManager = $this->getServiceManager(require __DIR__ . '/../../resources/config.php');
 
         $factory = new AutoWiringFactory();
 
         $instance = $factory->createService(
-            $container,
+            $serviceManager,
             ServiceBuildInTypeWithDefaultUsingConstant::class,
             ServiceBuildInTypeWithDefaultUsingConstant::class
         );
@@ -88,12 +88,12 @@ class AutoWiringFactoryTest extends AbstractIntegration
 
     public function testItCreatesServiceFromPluginManager(): void
     {
-        $container = $this->getServiceManager(require __DIR__ . '/../../resources/config.php');
+        $serviceManager = $this->getServiceManager(require __DIR__ . '/../../resources/config.php');
 
         $pluginManager = $this->createMock(AbstractPluginManager::class);
         $pluginManager->expects($this->atLeastOnce())
             ->method('getServiceLocator')
-            ->willReturn($container);
+            ->willReturn($serviceManager);
         $pluginManager->expects($this->once())
             ->method('has')
             ->with(Service2::class)
@@ -110,10 +110,10 @@ class AutoWiringFactoryTest extends AbstractIntegration
     {
         $this->expectException(InvalidServiceException::class);
 
-        $container = $this->getServiceManager(require __DIR__ . '/../../resources/config.php');
+        $serviceManager = $this->getServiceManager(require __DIR__ . '/../../resources/config.php');
 
         $factory = new AutoWiringFactory();
 
-        $factory->createService($container, 'NoServiceClass', 'NoServiceClass');
+        $factory->createService($serviceManager, 'NoServiceClass', 'NoServiceClass');
     }
 }

--- a/test/Integration/Factory/InjectionFactoryTest.php
+++ b/test/Integration/Factory/InjectionFactoryTest.php
@@ -7,6 +7,7 @@ namespace Reinfi\DependencyInjection\Test\Integration\Factory;
 use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
 use Laminas\Stdlib\ArrayUtils;
+use PHPUnit\Framework\Attributes\Group;
 use Reinfi\DependencyInjection\Factory\InjectionFactory;
 use Reinfi\DependencyInjection\Service\Extractor\YamlExtractor;
 use Reinfi\DependencyInjection\Test\Base\AbstractIntegration;
@@ -18,30 +19,29 @@ use Reinfi\DependencyInjection\Test\Service\ServiceAnnotationConstructor;
 
 /**
  * @package Reinfi\DependencyInjection\Test\Integration\Factory
- *
- * @group integration
  */
-class InjectionFactoryTest extends AbstractIntegration
+#[Group('integration')]
+final class InjectionFactoryTest extends AbstractIntegration
 {
     public function testItCreatesServiceWithDependencies(): void
     {
-        $container = $this->getServiceManager(require __DIR__ . '/../../resources/config.php');
+        $serviceManager = $this->getServiceManager(require __DIR__ . '/../../resources/config.php');
 
         $factory = new InjectionFactory();
 
-        $instance = $factory->createService($container, ServiceAnnotation::class, ServiceAnnotation::class);
+        $instance = $factory->createService($serviceManager, ServiceAnnotation::class, ServiceAnnotation::class);
 
         self::assertInstanceOf(ServiceAnnotation::class, $instance);
     }
 
     public function testItCreatesServiceWithDependenciesFromConstructor(): void
     {
-        $container = $this->getServiceManager(require __DIR__ . '/../../resources/config.php');
+        $serviceManager = $this->getServiceManager(require __DIR__ . '/../../resources/config.php');
 
         $factory = new InjectionFactory();
 
         $instance = $factory->createService(
-            $container,
+            $serviceManager,
             ServiceAnnotationConstructor::class,
             ServiceAnnotationConstructor::class
         );
@@ -51,7 +51,7 @@ class InjectionFactoryTest extends AbstractIntegration
 
     public function testItCreatesServiceWithNoInjectionsDefined(): void
     {
-        $container = $this->getServiceManager([
+        $serviceManager = $this->getServiceManager([
             'service_manager' => [
                 'factories' => [
                     Service3::class => InjectionFactory::class,
@@ -59,32 +59,32 @@ class InjectionFactoryTest extends AbstractIntegration
             ],
         ]);
 
-        $factory = new InjectionFactory();
+        $injectionFactory = new InjectionFactory();
 
-        $instance = $factory->createService($container, Service3::class, Service3::class);
+        $instance = $injectionFactory->createService($serviceManager, Service3::class, Service3::class);
 
         self::assertInstanceOf(Service3::class, $instance);
     }
 
     public function testItCreatesServiceFromCanonicalName(): void
     {
-        $container = $this->getServiceManager(require __DIR__ . '/../../resources/config.php');
+        $serviceManager = $this->getServiceManager(require __DIR__ . '/../../resources/config.php');
 
         $factory = new InjectionFactory();
 
-        $instance = $factory->createService($container, ServiceAnnotation::class, null);
+        $instance = $factory->createService($serviceManager, ServiceAnnotation::class, null);
 
         self::assertInstanceOf(ServiceAnnotation::class, $instance);
     }
 
     public function testItCreatesServiceFromPluginManager(): void
     {
-        $container = $this->getServiceManager(require __DIR__ . '/../../resources/config.php');
+        $serviceManager = $this->getServiceManager(require __DIR__ . '/../../resources/config.php');
 
         $pluginManager = $this->createMock(AbstractPluginManager::class);
         $pluginManager->expects($this->atLeastOnce())
             ->method('getServiceLocator')
-            ->willReturn($container);
+            ->willReturn($serviceManager);
 
         $factory = new InjectionFactory();
 
@@ -97,11 +97,11 @@ class InjectionFactoryTest extends AbstractIntegration
     {
         $this->expectException(InvalidServiceException::class);
 
-        $container = $this->getServiceManager(require __DIR__ . '/../../resources/config.php');
+        $serviceManager = $this->getServiceManager(require __DIR__ . '/../../resources/config.php');
 
         $factory = new InjectionFactory();
 
-        $factory->createService($container, 'NoServiceClass', 'NoServiceClass');
+        $factory->createService($serviceManager, 'NoServiceClass', 'NoServiceClass');
     }
 
     public function testItResolvesYamlInjections(): void

--- a/test/Service/BadInjectionClass.php
+++ b/test/Service/BadInjectionClass.php
@@ -11,13 +11,8 @@ namespace Reinfi\DependencyInjection\Test\Service;
  */
 class BadInjectionClass
 {
-    /**
-     * @var array
-     */
-    private $property;
-
-    public function __construct(array $property)
-    {
-        $this->property = $property;
+    public function __construct(
+        private readonly array $property
+    ) {
     }
 }

--- a/test/Service/PluginService.php
+++ b/test/Service/PluginService.php
@@ -11,15 +11,11 @@ use Reinfi\DependencyInjection\Annotation\InjectParent;
  */
 class PluginService
 {
-    /**
-     * @InjectParent("Reinfi\DependencyInjection\Test\Service\Service2")
-     *
-     * @var Service2
-     */
-    protected $service2;
-
-    public function __construct(Service2 $service2)
-    {
-        $this->service2 = $service2;
+    public function __construct(
+        /**
+         * @InjectParent("Reinfi\DependencyInjection\Test\Service\Service2")
+         */
+        protected Service2 $service2
+    ) {
     }
 }

--- a/test/Service/Resolver/TestResolver.php
+++ b/test/Service/Resolver/TestResolver.php
@@ -13,7 +13,7 @@ use Reinfi\DependencyInjection\Service\AutoWiring\Resolver\ResolverInterface;
  */
 class TestResolver implements ResolverInterface
 {
-    public function resolve(ReflectionParameter $parameter): ?InjectionInterface
+    public function resolve(ReflectionParameter $reflectionParameter): ?InjectionInterface
     {
         return null;
     }

--- a/test/Service/ServiceAnnotation.php
+++ b/test/Service/ServiceAnnotation.php
@@ -12,31 +12,19 @@ use Reinfi\DependencyInjection\Annotation\InjectConfig;
  */
 class ServiceAnnotation
 {
-    /**
-     * @Inject("Reinfi\DependencyInjection\Test\Service\Service2")
-     *
-     * @var Service2
-     */
-    protected $service2;
-
-    /**
-     * @InjectConfig("test.value")
-     *
-     * @var int
-     */
-    protected $value;
-
-    /**
-     * @InjectConfig("test", asArray=true)
-     *
-     * @var array
-     */
-    protected $valueAsArray;
-
-    public function __construct(Service2 $service2, int $value, array $valueAsArray)
-    {
-        $this->service2 = $service2;
-        $this->value = $value;
-        $this->valueAsArray = $valueAsArray;
+    public function __construct(
+        /**
+         * @Inject("Reinfi\DependencyInjection\Test\Service\Service2")
+         */
+        protected Service2 $service2,
+        /**
+         * @InjectConfig("test.value")
+         */
+        protected int $value,
+        /**
+         * @InjectConfig("test", asArray=true)
+         */
+        protected array $valueAsArray
+    ) {
     }
 }

--- a/test/Service/ServiceAnnotationConstructor.php
+++ b/test/Service/ServiceAnnotationConstructor.php
@@ -14,29 +14,14 @@ use Reinfi\DependencyInjection\Annotation\InjectConstant;
 class ServiceAnnotationConstructor
 {
     /**
-     * @var Service2
-     */
-    protected $service2;
-
-    /**
-     * @var int
-     */
-    protected $value;
-
-    /**
-     * @var string
-     */
-    protected $constant;
-
-    /**
      * @Inject("Reinfi\DependencyInjection\Test\Service\Service2")
      * @InjectConfig("test.value")
      * @InjectConstant("Reinfi\DependencyInjection\Test\Service\Service2::CONSTANT")
      */
-    public function __construct(Service2 $service2, int $value, string $constant)
-    {
-        $this->service2 = $service2;
-        $this->value = $value;
-        $this->constant = $constant;
+    public function __construct(
+        protected Service2 $service2,
+        protected int $value,
+        protected string $constant
+    ) {
     }
 }

--- a/test/Service/ServiceAttribute.php
+++ b/test/Service/ServiceAttribute.php
@@ -10,19 +10,13 @@ use Reinfi\DependencyInjection\Attribute\InjectConstant;
 
 class ServiceAttribute
 {
-    #[Inject('Reinfi\DependencyInjection\Test\Service\Service2')]
-    private Service2 $service2;
-
-    #[InjectConstant(PHP_VERSION)]
-    private string $version;
-
-    #[InjectConfig('test.value')]
-    private int $testValue;
-
-    public function __construct(Service2 $service2, string $version, int $testValue)
-    {
-        $this->service2 = $service2;
-        $this->version = $version;
-        $this->testValue = $testValue;
+    public function __construct(
+        #[Inject('Reinfi\DependencyInjection\Test\Service\Service2')]
+        private readonly Service2 $service2,
+        #[InjectConstant(PHP_VERSION)]
+        private readonly string $version,
+        #[InjectConfig('test.value')]
+        private readonly int $testValue
+    ) {
     }
 }

--- a/test/Service/ServiceAttributeConstructor.php
+++ b/test/Service/ServiceAttributeConstructor.php
@@ -8,11 +8,9 @@ use Reinfi\DependencyInjection\Attribute\Inject;
 
 class ServiceAttributeConstructor
 {
-    private Service2 $service2;
-
     #[Inject('Reinfi\DependencyInjection\Test\Service\Service2')]
-    public function __construct(Service2 $service2)
-    {
-        $this->service2 = $service2;
+    public function __construct(
+        private readonly Service2 $service2
+    ) {
     }
 }

--- a/test/Service/ServiceBuildInTypeWithDefaultUsingConstant.php
+++ b/test/Service/ServiceBuildInTypeWithDefaultUsingConstant.php
@@ -9,7 +9,7 @@ namespace Reinfi\DependencyInjection\Test\Service;
  */
 class ServiceBuildInTypeWithDefaultUsingConstant
 {
-    private const DEFAULT = 1;
+    private const int DEFAULT = 1;
 
     public function __construct(
         Service1 $service1,

--- a/test/Unit/AbstractFactory/Config/InjectConfigAbstractFactoryTest.php
+++ b/test/Unit/AbstractFactory/Config/InjectConfigAbstractFactoryTest.php
@@ -12,35 +12,35 @@ use Reinfi\DependencyInjection\Service\ConfigService;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\AbstractFactory\Config
  */
-class InjectConfigAbstractFactoryTest extends TestCase
+final class InjectConfigAbstractFactoryTest extends TestCase
 {
     public function testItCanCreateServiceWithConfigPattern(): void
     {
-        $factory = new InjectConfigAbstractFactory();
+        $injectConfigAbstractFactory = new InjectConfigAbstractFactory();
 
         $container = $this->createMock(ContainerInterface::class);
 
         self::assertTrue(
-            $factory->canCreate($container, 'Config.reinfi.di.test'),
+            $injectConfigAbstractFactory->canCreate($container, 'Config.reinfi.di.test'),
             'factory should be able to create service'
         );
     }
 
     public function testItCanNotCreateServiceWithNonConfigPattern(): void
     {
-        $factory = new InjectConfigAbstractFactory();
+        $injectConfigAbstractFactory = new InjectConfigAbstractFactory();
 
         $container = $this->createMock(ContainerInterface::class);
 
         self::assertFalse(
-            $factory->canCreate($container, 'service.reinfi.di.test'),
+            $injectConfigAbstractFactory->canCreate($container, 'service.reinfi.di.test'),
             'factory should not be able to create service'
         );
     }
 
     public function testItCallsConfigServiceForConfigPattern(): void
     {
-        $factory = new InjectConfigAbstractFactory();
+        $injectConfigAbstractFactory = new InjectConfigAbstractFactory();
 
         $configService = $this->createMock(ConfigService::class);
         $configService->expects($this->once())
@@ -53,9 +53,9 @@ class InjectConfigAbstractFactoryTest extends TestCase
             ->with(ConfigService::class)
             ->willReturn($configService);
 
-        $factory->canCreate($container, 'Config.reinfi.di.test');
+        $injectConfigAbstractFactory->canCreate($container, 'Config.reinfi.di.test');
 
-        $factory(
+        $injectConfigAbstractFactory(
             $container,
             'config.reinfi.di.test',
         );

--- a/test/Unit/Annotation/InjectConfigTest.php
+++ b/test/Unit/Annotation/InjectConfigTest.php
@@ -14,11 +14,11 @@ use Reinfi\DependencyInjection\Service\ConfigService;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Annotation
  */
-class InjectConfigTest extends TestCase
+final class InjectConfigTest extends TestCase
 {
     public function testItCallsConfigServiceFromContainerWithValue(): void
     {
-        $inject = new InjectConfig([
+        $injectConfig = new InjectConfig([
             'value' => 'reinfi.di.test',
         ]);
 
@@ -34,12 +34,12 @@ class InjectConfigTest extends TestCase
             ->with(ConfigService::class)
             ->willReturn($configService);
 
-        self::assertTrue($inject($container), 'Invoke should return true');
+        self::assertTrue($injectConfig($container), 'Invoke should return true');
     }
 
     public function testItCallsConfigServiceFromPluginManagerWithValue(): void
     {
-        $inject = new InjectConfig([
+        $injectConfig = new InjectConfig([
             'value' => 'reinfi.di.test',
         ]);
 
@@ -60,12 +60,12 @@ class InjectConfigTest extends TestCase
             ->method('getServiceLocator')
             ->willReturn($container);
 
-        self::assertTrue($inject($pluginManager), 'Invoke should return true');
+        self::assertTrue($injectConfig($pluginManager), 'Invoke should return true');
     }
 
     public function testItReturnsArrayIfPropertyIsSet(): void
     {
-        $inject = new InjectConfig([
+        $injectConfig = new InjectConfig([
             'value' => 'reinfi.di.test',
             'asArray' => true,
         ]);
@@ -87,6 +87,6 @@ class InjectConfigTest extends TestCase
             ->with(ConfigService::class)
             ->willReturn($configService);
 
-        self::assertEquals([true], $inject($container), 'Invoke should return array containing true');
+        self::assertEquals([true], $injectConfig($container), 'Invoke should return array containing true');
     }
 }

--- a/test/Unit/Annotation/InjectConstantTest.php
+++ b/test/Unit/Annotation/InjectConstantTest.php
@@ -12,15 +12,15 @@ use Reinfi\DependencyInjection\Test\Service\Service2;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Annotation
  */
-class InjectConstantTest extends TestCase
+final class InjectConstantTest extends TestCase
 {
     public function testItShouldConvertScalarTypes(): void
     {
-        $injectScalar = new InjectConstant();
-        $injectScalar->value = Service2::class . '::CONSTANT';
+        $injectConstant = new InjectConstant();
+        $injectConstant->value = Service2::class . '::CONSTANT';
 
         $container = $this->createMock(ContainerInterface::class);
 
-        self::assertSame(Service2::CONSTANT, $injectScalar($container));
+        self::assertSame(Service2::CONSTANT, $injectConstant($container));
     }
 }

--- a/test/Unit/Annotation/InjectContainerTest.php
+++ b/test/Unit/Annotation/InjectContainerTest.php
@@ -11,14 +11,14 @@ use Reinfi\DependencyInjection\Annotation\InjectContainer;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Annotation
  */
-class InjectContainerTest extends TestCase
+final class InjectContainerTest extends TestCase
 {
     public function testItCallsContainerWithValue(): void
     {
-        $inject = new InjectContainer();
+        $injectContainer = new InjectContainer();
 
         $container = $this->createMock(ContainerInterface::class);
 
-        self::assertEquals($container, $inject($container), 'Invoke should return provided container');
+        self::assertEquals($container, $injectContainer($container), 'Invoke should return provided container');
     }
 }

--- a/test/Unit/Annotation/InjectControllerPluginTest.php
+++ b/test/Unit/Annotation/InjectControllerPluginTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Reinfi\DependencyInjection\Test\Unit\Annotation;
 
+use Iterator;
 use Laminas\ServiceManager\AbstractPluginManager;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -14,12 +15,12 @@ use Reinfi\DependencyInjection\Test\Service\Service1;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Annotation
  */
-class InjectControllerPluginTest extends TestCase
+final class InjectControllerPluginTest extends TestCase
 {
     #[DataProvider('getAnnotationValues')]
     public function testItCallsPluginManagerWithValue(array $values, string $className): void
     {
-        $inject = new InjectControllerPlugin($values);
+        $injectControllerPlugin = new InjectControllerPlugin($values);
 
         $pluginManager = $this->createMock(AbstractPluginManager::class);
 
@@ -41,13 +42,13 @@ class InjectControllerPluginTest extends TestCase
             ->with('ControllerPluginManager')
             ->willReturn($pluginManager);
 
-        self::assertTrue($inject($container), 'Invoke should return true');
+        self::assertTrue($injectControllerPlugin($container), 'Invoke should return true');
     }
 
     #[DataProvider('getAnnotationValues')]
     public function testItCallsPluginManagerFromParentServiceLocator(array $values, string $className): void
     {
-        $inject = new InjectControllerPlugin($values);
+        $injectControllerPlugin = new InjectControllerPlugin($values);
 
         $filterManager = $this->createMock(AbstractPluginManager::class);
 
@@ -74,33 +75,31 @@ class InjectControllerPluginTest extends TestCase
             ->method('getServiceLocator')
             ->willReturn($container);
 
-        self::assertTrue($inject($pluginManager), 'Invoke should return true');
+        self::assertTrue($injectControllerPlugin($pluginManager), 'Invoke should return true');
     }
 
-    public static function getAnnotationValues(): array
+    public static function getAnnotationValues(): Iterator
     {
-        return [
+        yield [
             [
-                [
-                    'value' => Service1::class,
-                ],
-                Service1::class,
+                'value' => Service1::class,
             ],
+            Service1::class,
+        ];
+        yield [
             [
-                [
-                    'name' => Service1::class,
-                    'options' => [
-                        'field' => true,
-                    ],
+                'name' => Service1::class,
+                'options' => [
+                    'field' => true,
                 ],
-                Service1::class,
             ],
+            Service1::class,
+        ];
+        yield [
             [
-                [
-                    'name' => Service1::class,
-                ],
-                Service1::class,
+                'name' => Service1::class,
             ],
+            Service1::class,
         ];
     }
 }

--- a/test/Unit/Annotation/InjectDoctrineRepositoryTest.php
+++ b/test/Unit/Annotation/InjectDoctrineRepositoryTest.php
@@ -6,6 +6,7 @@ namespace Reinfi\DependencyInjection\Test\Unit\Annotation;
 
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityRepository;
+use Iterator;
 use Laminas\ServiceManager\AbstractPluginManager;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -15,30 +16,30 @@ use Reinfi\DependencyInjection\Annotation\InjectDoctrineRepository;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Annotation
  */
-class InjectDoctrineRepositoryTest extends TestCase
+final class InjectDoctrineRepositoryTest extends TestCase
 {
     #[DataProvider('getAnnotationValuesWithoutEntityManager')]
     public function testItGetsRepositoryWithoutEntityManagerSet(array $values, string $repositoryClass): void
     {
-        $inject = new InjectDoctrineRepository($values);
+        $injectDoctrineRepository = new InjectDoctrineRepository($values);
 
-        $repository = $this->createMock($repositoryClass);
+        $mockObject = $this->createMock($repositoryClass);
 
         $entityManager = $this->createMock(EntityManager::class);
         $entityManager->expects($this->once())
             ->method('getRepository')
-            ->with($this->equalTo($repositoryClass))
-            ->willReturn($repository);
+            ->with($repositoryClass)
+            ->willReturn($mockObject);
 
         $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->once())
             ->method('get')
-            ->with($this->equalTo('Doctrine\ORM\EntityManager'))
+            ->with('Doctrine\ORM\EntityManager')
             ->willReturn($entityManager);
 
         self::assertInstanceOf(
             $repositoryClass,
-            $inject($container),
+            $injectDoctrineRepository($container),
             'Should be instance of repositoryClass ' . $repositoryClass
         );
     }
@@ -49,25 +50,25 @@ class InjectDoctrineRepositoryTest extends TestCase
         string $entityManagerIdentifier,
         string $repositoryClass
     ): void {
-        $inject = new InjectDoctrineRepository($values);
+        $injectDoctrineRepository = new InjectDoctrineRepository($values);
 
-        $repository = $this->createMock($repositoryClass);
+        $mockObject = $this->createMock($repositoryClass);
 
         $entityManager = $this->createMock(EntityManager::class);
         $entityManager->expects($this->once())
             ->method('getRepository')
-            ->with($this->equalTo($repositoryClass))
-            ->willReturn($repository);
+            ->with($repositoryClass)
+            ->willReturn($mockObject);
 
         $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->once())
             ->method('get')
-            ->with($this->equalTo($entityManagerIdentifier))
+            ->with($entityManagerIdentifier)
             ->willReturn($entityManager);
 
         self::assertInstanceOf(
             $repositoryClass,
-            $inject($container),
+            $injectDoctrineRepository($container),
             'Should be instance of repositoryClass ' . $repositoryClass
         );
     }
@@ -79,20 +80,20 @@ class InjectDoctrineRepositoryTest extends TestCase
     #[DataProvider('getAnnotationValuesWithoutEntityManager')]
     public function testItGetsRepositoryFromPluginManager(array $values, string $repositoryClass): void
     {
-        $inject = new InjectDoctrineRepository($values);
+        $injectDoctrineRepository = new InjectDoctrineRepository($values);
 
-        $repository = $this->createMock($repositoryClass);
+        $mockObject = $this->createMock($repositoryClass);
 
         $entityManager = $this->createMock(EntityManager::class);
         $entityManager->expects($this->once())
             ->method('getRepository')
-            ->with($this->equalTo($repositoryClass))
-            ->willReturn($repository);
+            ->with($repositoryClass)
+            ->willReturn($mockObject);
 
         $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->once())
             ->method('get')
-            ->with($this->equalTo('Doctrine\ORM\EntityManager'))
+            ->with('Doctrine\ORM\EntityManager')
             ->willReturn($entityManager);
 
         $pluginManager = $this->createMock(AbstractPluginManager::class);
@@ -102,48 +103,44 @@ class InjectDoctrineRepositoryTest extends TestCase
 
         self::assertInstanceOf(
             $repositoryClass,
-            $inject($pluginManager),
+            $injectDoctrineRepository($pluginManager),
             'Should be instance of repositoryClass ' . $repositoryClass
         );
     }
 
-    public static function getAnnotationValuesWithoutEntityManager(): array
+    public static function getAnnotationValuesWithoutEntityManager(): Iterator
     {
-        return [
+        yield [
             [
-                [
-                    'value' => EntityRepository::class,
-                ],
-                EntityRepository::class,
+                'value' => EntityRepository::class,
             ],
+            EntityRepository::class,
+        ];
+        yield [
             [
-                [
-                    'entity' => EntityRepository::class,
-                ],
-                EntityRepository::class,
+                'entity' => EntityRepository::class,
             ],
+            EntityRepository::class,
         ];
     }
 
-    public static function getAnnotationValuesWithEntityManager(): array
+    public static function getAnnotationValuesWithEntityManager(): Iterator
     {
-        return [
+        yield [
             [
-                [
-                    'entity' => EntityRepository::class,
-                    'em' => 'doctrine.entityManager',
-                ],
-                'doctrine.entityManager',
-                EntityRepository::class,
+                'entity' => EntityRepository::class,
+                'em' => 'doctrine.entityManager',
             ],
+            'doctrine.entityManager',
+            EntityRepository::class,
+        ];
+        yield [
             [
-                [
-                    'entity' => EntityRepository::class,
-                    'entityManager' => 'doctrine.entityManager',
-                ],
-                'doctrine.entityManager',
-                EntityRepository::class,
+                'entity' => EntityRepository::class,
+                'entityManager' => 'doctrine.entityManager',
             ],
+            'doctrine.entityManager',
+            EntityRepository::class,
         ];
     }
 }

--- a/test/Unit/Annotation/InjectFilterTest.php
+++ b/test/Unit/Annotation/InjectFilterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Reinfi\DependencyInjection\Test\Unit\Annotation;
 
+use Iterator;
 use Laminas\ServiceManager\AbstractPluginManager;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -14,12 +15,12 @@ use Reinfi\DependencyInjection\Test\Service\Service1;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Annotation
  */
-class InjectFilterTest extends TestCase
+final class InjectFilterTest extends TestCase
 {
     #[DataProvider('getAnnotationValues')]
     public function testItCallsPluginManagerWithValue(array $values, string $className): void
     {
-        $inject = new InjectFilter($values);
+        $injectFilter = new InjectFilter($values);
 
         $pluginManager = $this->createMock(AbstractPluginManager::class);
 
@@ -41,13 +42,13 @@ class InjectFilterTest extends TestCase
             ->with('FilterManager')
             ->willReturn($pluginManager);
 
-        self::assertTrue($inject($container), 'Invoke should return true');
+        self::assertTrue($injectFilter($container), 'Invoke should return true');
     }
 
     #[DataProvider('getAnnotationValues')]
     public function testItCallsPluginManagerFromParentServiceLocator(array $values, string $className): void
     {
-        $inject = new InjectFilter($values);
+        $injectFilter = new InjectFilter($values);
 
         $filterManager = $this->createMock(AbstractPluginManager::class);
 
@@ -74,33 +75,31 @@ class InjectFilterTest extends TestCase
             ->method('getServiceLocator')
             ->willReturn($container);
 
-        self::assertTrue($inject($pluginManager), 'Invoke should return true');
+        self::assertTrue($injectFilter($pluginManager), 'Invoke should return true');
     }
 
-    public static function getAnnotationValues(): array
+    public static function getAnnotationValues(): Iterator
     {
-        return [
+        yield [
             [
-                [
-                    'value' => Service1::class,
-                ],
-                Service1::class,
+                'value' => Service1::class,
             ],
+            Service1::class,
+        ];
+        yield [
             [
-                [
-                    'name' => Service1::class,
-                    'options' => [
-                        'field' => true,
-                    ],
+                'name' => Service1::class,
+                'options' => [
+                    'field' => true,
                 ],
-                Service1::class,
             ],
+            Service1::class,
+        ];
+        yield [
             [
-                [
-                    'name' => Service1::class,
-                ],
-                Service1::class,
+                'name' => Service1::class,
             ],
+            Service1::class,
         ];
     }
 }

--- a/test/Unit/Annotation/InjectFormElementTest.php
+++ b/test/Unit/Annotation/InjectFormElementTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Reinfi\DependencyInjection\Test\Unit\Annotation;
 
+use Iterator;
 use Laminas\ServiceManager\AbstractPluginManager;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -14,12 +15,12 @@ use Reinfi\DependencyInjection\Test\Service\Service1;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Annotation
  */
-class InjectFormElementTest extends TestCase
+final class InjectFormElementTest extends TestCase
 {
     #[DataProvider('getAnnotationValues')]
     public function testItCallsPluginManagerWithValue(array $values, string $className): void
     {
-        $inject = new InjectFormElement($values);
+        $injectFormElement = new InjectFormElement($values);
 
         $pluginManager = $this->createMock(AbstractPluginManager::class);
 
@@ -41,13 +42,13 @@ class InjectFormElementTest extends TestCase
             ->with('FormElementManager')
             ->willReturn($pluginManager);
 
-        self::assertTrue($inject($container), 'Invoke should return true');
+        self::assertTrue($injectFormElement($container), 'Invoke should return true');
     }
 
     #[DataProvider('getAnnotationValues')]
     public function testItCallsPluginManagerFromParentServiceLocator(array $values, string $className): void
     {
-        $inject = new InjectFormElement($values);
+        $injectFormElement = new InjectFormElement($values);
 
         $filterManager = $this->createMock(AbstractPluginManager::class);
 
@@ -74,33 +75,31 @@ class InjectFormElementTest extends TestCase
             ->method('getServiceLocator')
             ->willReturn($container);
 
-        self::assertTrue($inject($pluginManager), 'Invoke should return true');
+        self::assertTrue($injectFormElement($pluginManager), 'Invoke should return true');
     }
 
-    public static function getAnnotationValues(): array
+    public static function getAnnotationValues(): Iterator
     {
-        return [
+        yield [
             [
-                [
-                    'value' => Service1::class,
-                ],
-                Service1::class,
+                'value' => Service1::class,
             ],
+            Service1::class,
+        ];
+        yield [
             [
-                [
-                    'name' => Service1::class,
-                    'options' => [
-                        'field' => true,
-                    ],
+                'name' => Service1::class,
+                'options' => [
+                    'field' => true,
                 ],
-                Service1::class,
             ],
+            Service1::class,
+        ];
+        yield [
             [
-                [
-                    'name' => Service1::class,
-                ],
-                Service1::class,
+                'name' => Service1::class,
             ],
+            Service1::class,
         ];
     }
 }

--- a/test/Unit/Annotation/InjectHydratorTest.php
+++ b/test/Unit/Annotation/InjectHydratorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Reinfi\DependencyInjection\Test\Unit\Annotation;
 
+use Iterator;
 use Laminas\ServiceManager\AbstractPluginManager;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -14,59 +15,59 @@ use Reinfi\DependencyInjection\Test\Service\Service1;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Annotation
  */
-class InjectHydratorTest extends TestCase
+final class InjectHydratorTest extends TestCase
 {
     #[DataProvider('getAnnotationValues')]
     public function testItCallsPluginManagerWithValue(array $values, string $className): void
     {
-        $inject = new InjectHydrator($values);
+        $injectHydrator = new InjectHydrator($values);
 
         $pluginManager = $this->createMock(AbstractPluginManager::class);
 
         if (isset($values['options'])) {
             $pluginManager->expects($this->once())
                 ->method('get')
-                ->with($this->equalTo($className), $this->equalTo($values['options']))
+                ->with($className, $values['options'])
                 ->willReturn(true);
         } else {
             $pluginManager->expects($this->once())
                 ->method('get')
-                ->with($this->equalTo($className))
+                ->with($className)
                 ->willReturn(true);
         }
 
         $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->once())
             ->method('get')
-            ->with($this->equalTo('HydratorManager'))
+            ->with('HydratorManager')
             ->willReturn($pluginManager);
 
-        self::assertTrue($inject($container), 'Invoke should return true');
+        self::assertTrue($injectHydrator($container), 'Invoke should return true');
     }
 
     #[DataProvider('getAnnotationValues')]
     public function testItCallsPluginManagerFromParentServiceLocator(array $values, string $className): void
     {
-        $inject = new InjectHydrator($values);
+        $injectHydrator = new InjectHydrator($values);
 
         $filterManager = $this->createMock(AbstractPluginManager::class);
 
         if (isset($values['options'])) {
             $filterManager->expects($this->once())
                 ->method('get')
-                ->with($this->equalTo($className), $this->equalTo($values['options']))
+                ->with($className, $values['options'])
                 ->willReturn(true);
         } else {
             $filterManager->expects($this->once())
                 ->method('get')
-                ->with($this->equalTo($className))
+                ->with($className)
                 ->willReturn(true);
         }
 
         $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->once())
             ->method('get')
-            ->with($this->equalTo('HydratorManager'))
+            ->with('HydratorManager')
             ->willReturn($filterManager);
 
         $pluginManager = $this->createMock(AbstractPluginManager::class);
@@ -74,34 +75,34 @@ class InjectHydratorTest extends TestCase
             ->method('getServiceLocator')
             ->willReturn($container);
 
-        self::assertTrue($inject($pluginManager), 'Invoke should return true');
+        self::assertTrue($injectHydrator($pluginManager), 'Invoke should return true');
     }
 
     #[DataProvider('getAnnotationValues')]
     public function testItShouldReturnContainerServiceKey(array $values, string $expectedValue): void
     {
-        $inject = new InjectHydrator($values);
+        $injectHydrator = new InjectHydrator($values);
 
         // Create a mock container to verify the service name through the __invoke method
         $pluginManager = $this->createMock(AbstractPluginManager::class);
         $pluginManager->expects($this->once())
             ->method('get')
-            ->with($this->equalTo($expectedValue))
+            ->with($expectedValue)
             ->willReturn(true);
 
         $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->once())
             ->method('get')
-            ->with($this->equalTo('HydratorManager'))
+            ->with('HydratorManager')
             ->willReturn($pluginManager);
 
-        $inject($container);
+        $injectHydrator($container);
     }
 
     #[DataProvider('getAnnotationValues')]
     public function testItShouldBuildWithValues(array $values, string $className): void
     {
-        $inject = new InjectHydrator($values);
+        $injectHydrator = new InjectHydrator($values);
 
         // Create a mock container to verify the values through the __invoke method
         $pluginManager = $this->createMock(AbstractPluginManager::class);
@@ -109,48 +110,46 @@ class InjectHydratorTest extends TestCase
         if (isset($values['options'])) {
             $pluginManager->expects($this->once())
                 ->method('get')
-                ->with($this->equalTo($values['value'] ?? $values['name']), $this->equalTo($values['options']))
+                ->with($values['value'] ?? $values['name'], $values['options'])
                 ->willReturn(true);
         } else {
             $pluginManager->expects($this->once())
                 ->method('get')
-                ->with($this->equalTo($values['value'] ?? $values['name']))
+                ->with($values['value'] ?? $values['name'])
                 ->willReturn(true);
         }
 
         $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->once())
             ->method('get')
-            ->with($this->equalTo('HydratorManager'))
+            ->with('HydratorManager')
             ->willReturn($pluginManager);
 
-        $inject($container);
+        $injectHydrator($container);
     }
 
-    public static function getAnnotationValues(): array
+    public static function getAnnotationValues(): Iterator
     {
-        return [
+        yield [
             [
-                [
-                    'value' => Service1::class,
-                ],
-                Service1::class,
+                'value' => Service1::class,
             ],
+            Service1::class,
+        ];
+        yield [
             [
-                [
-                    'name' => Service1::class,
-                    'options' => [
-                        'field' => true,
-                    ],
+                'name' => Service1::class,
+                'options' => [
+                    'field' => true,
                 ],
-                Service1::class,
             ],
+            Service1::class,
+        ];
+        yield [
             [
-                [
-                    'name' => Service1::class,
-                ],
-                Service1::class,
+                'name' => Service1::class,
             ],
+            Service1::class,
         ];
     }
 }

--- a/test/Unit/Annotation/InjectInputFilterTest.php
+++ b/test/Unit/Annotation/InjectInputFilterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Reinfi\DependencyInjection\Test\Unit\Annotation;
 
+use Iterator;
 use Laminas\ServiceManager\AbstractPluginManager;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -14,12 +15,12 @@ use Reinfi\DependencyInjection\Test\Service\Service1;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Annotation
  */
-class InjectInputFilterTest extends TestCase
+final class InjectInputFilterTest extends TestCase
 {
     #[DataProvider('getAnnotationValues')]
     public function testItCallsPluginManagerWithValue(array $values, string $className): void
     {
-        $inject = new InjectInputFilter($values);
+        $injectInputFilter = new InjectInputFilter($values);
 
         $pluginManager = $this->createMock(AbstractPluginManager::class);
 
@@ -41,13 +42,13 @@ class InjectInputFilterTest extends TestCase
             ->with('InputFilterManager')
             ->willReturn($pluginManager);
 
-        self::assertTrue($inject($container), 'Invoke should return true');
+        self::assertTrue($injectInputFilter($container), 'Invoke should return true');
     }
 
     #[DataProvider('getAnnotationValues')]
     public function testItCallsPluginManagerFromParentServiceLocator(array $values, string $className): void
     {
-        $inject = new InjectInputFilter($values);
+        $injectInputFilter = new InjectInputFilter($values);
 
         $filterManager = $this->createMock(AbstractPluginManager::class);
 
@@ -74,33 +75,31 @@ class InjectInputFilterTest extends TestCase
             ->method('getServiceLocator')
             ->willReturn($container);
 
-        self::assertTrue($inject($pluginManager), 'Invoke should return true');
+        self::assertTrue($injectInputFilter($pluginManager), 'Invoke should return true');
     }
 
-    public static function getAnnotationValues(): array
+    public static function getAnnotationValues(): Iterator
     {
-        return [
+        yield [
             [
-                [
-                    'value' => Service1::class,
-                ],
-                Service1::class,
+                'value' => Service1::class,
             ],
+            Service1::class,
+        ];
+        yield [
             [
-                [
-                    'name' => Service1::class,
-                    'options' => [
-                        'field' => true,
-                    ],
+                'name' => Service1::class,
+                'options' => [
+                    'field' => true,
                 ],
-                Service1::class,
             ],
+            Service1::class,
+        ];
+        yield [
             [
-                [
-                    'name' => Service1::class,
-                ],
-                Service1::class,
+                'name' => Service1::class,
             ],
+            Service1::class,
         ];
     }
 }

--- a/test/Unit/Annotation/InjectParentTest.php
+++ b/test/Unit/Annotation/InjectParentTest.php
@@ -13,31 +13,31 @@ use Reinfi\DependencyInjection\Service\InjectionService;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Annotation
  */
-class InjectParentTest extends TestCase
+final class InjectParentTest extends TestCase
 {
     public function testItCallsContainerWithValue(): void
     {
-        $inject = new InjectParent();
-        $inject->value = InjectionService::class;
+        $injectParent = new InjectParent();
+        $injectParent->value = InjectionService::class;
 
         $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->once())
             ->method('get')
-            ->with($this->equalTo(InjectionService::class))
+            ->with(InjectionService::class)
             ->willReturn(true);
 
-        self::assertTrue($inject($container), 'Invoke should return true');
+        self::assertTrue($injectParent($container), 'Invoke should return true');
     }
 
     public function testItCallsParentContainerWhenPluginManager(): void
     {
-        $inject = new InjectParent();
-        $inject->value = InjectionService::class;
+        $injectParent = new InjectParent();
+        $injectParent->value = InjectionService::class;
 
         $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->once())
             ->method('get')
-            ->with($this->equalTo(InjectionService::class))
+            ->with(InjectionService::class)
             ->willReturn(true);
 
         $pluginManager = $this->createMock(AbstractPluginManager::class);
@@ -45,6 +45,6 @@ class InjectParentTest extends TestCase
             ->method('getServiceLocator')
             ->willReturn($container);
 
-        self::assertTrue($inject($pluginManager), 'Invoke should return true');
+        self::assertTrue($injectParent($pluginManager), 'Invoke should return true');
     }
 }

--- a/test/Unit/Annotation/InjectTest.php
+++ b/test/Unit/Annotation/InjectTest.php
@@ -12,7 +12,7 @@ use Reinfi\DependencyInjection\Service\InjectionService;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Annotation
  */
-class InjectTest extends TestCase
+final class InjectTest extends TestCase
 {
     public function testItCallsContainerWithValue(): void
     {
@@ -22,7 +22,7 @@ class InjectTest extends TestCase
         $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->once())
             ->method('get')
-            ->with($this->equalTo(InjectionService::class))
+            ->with(InjectionService::class)
             ->willReturn(true);
 
         self::assertTrue($inject($container), 'Invoke should return true');

--- a/test/Unit/Annotation/InjectValidatorTest.php
+++ b/test/Unit/Annotation/InjectValidatorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Reinfi\DependencyInjection\Test\Unit\Annotation;
 
+use Iterator;
 use Laminas\ServiceManager\AbstractPluginManager;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -14,59 +15,59 @@ use Reinfi\DependencyInjection\Test\Service\Service1;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Annotation
  */
-class InjectValidatorTest extends TestCase
+final class InjectValidatorTest extends TestCase
 {
     #[DataProvider('getAnnotationValues')]
     public function testItCallsPluginManagerWithValue(array $values, string $className): void
     {
-        $inject = new InjectValidator($values);
+        $injectValidator = new InjectValidator($values);
 
         $pluginManager = $this->createMock(AbstractPluginManager::class);
 
         if (isset($values['options'])) {
             $pluginManager->expects($this->once())
                 ->method('get')
-                ->with($this->equalTo($className), $this->equalTo($values['options']))
+                ->with($className, $values['options'])
                 ->willReturn(true);
         } else {
             $pluginManager->expects($this->once())
                 ->method('get')
-                ->with($this->equalTo($className))
+                ->with($className)
                 ->willReturn(true);
         }
 
         $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->once())
             ->method('get')
-            ->with($this->equalTo('ValidatorManager'))
+            ->with('ValidatorManager')
             ->willReturn($pluginManager);
 
-        self::assertTrue($inject($container), 'Invoke should return true');
+        self::assertTrue($injectValidator($container), 'Invoke should return true');
     }
 
     #[DataProvider('getAnnotationValues')]
     public function testItCallsPluginManagerFromParentServiceLocator(array $values, string $className): void
     {
-        $inject = new InjectValidator($values);
+        $injectValidator = new InjectValidator($values);
 
         $filterManager = $this->createMock(AbstractPluginManager::class);
 
         if (isset($values['options'])) {
             $filterManager->expects($this->once())
                 ->method('get')
-                ->with($this->equalTo($className), $this->equalTo($values['options']))
+                ->with($className, $values['options'])
                 ->willReturn(true);
         } else {
             $filterManager->expects($this->once())
                 ->method('get')
-                ->with($this->equalTo($className))
+                ->with($className)
                 ->willReturn(true);
         }
 
         $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->once())
             ->method('get')
-            ->with($this->equalTo('ValidatorManager'))
+            ->with('ValidatorManager')
             ->willReturn($filterManager);
 
         $pluginManager = $this->createMock(AbstractPluginManager::class);
@@ -74,33 +75,31 @@ class InjectValidatorTest extends TestCase
             ->method('getServiceLocator')
             ->willReturn($container);
 
-        self::assertTrue($inject($pluginManager), 'Invoke should return true');
+        self::assertTrue($injectValidator($pluginManager), 'Invoke should return true');
     }
 
-    public static function getAnnotationValues(): array
+    public static function getAnnotationValues(): Iterator
     {
-        return [
+        yield [
             [
-                [
-                    'value' => Service1::class,
-                ],
-                Service1::class,
+                'value' => Service1::class,
             ],
+            Service1::class,
+        ];
+        yield [
             [
-                [
-                    'name' => Service1::class,
-                    'options' => [
-                        'field' => true,
-                    ],
+                'name' => Service1::class,
+                'options' => [
+                    'field' => true,
                 ],
-                Service1::class,
             ],
+            Service1::class,
+        ];
+        yield [
             [
-                [
-                    'name' => Service1::class,
-                ],
-                Service1::class,
+                'name' => Service1::class,
             ],
+            Service1::class,
         ];
     }
 }

--- a/test/Unit/Annotation/InjectViewHelperTest.php
+++ b/test/Unit/Annotation/InjectViewHelperTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Reinfi\DependencyInjection\Test\Unit\Annotation;
 
+use Iterator;
 use Laminas\ServiceManager\AbstractPluginManager;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -14,12 +15,12 @@ use Reinfi\DependencyInjection\Test\Service\Service1;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Annotation
  */
-class InjectViewHelperTest extends TestCase
+final class InjectViewHelperTest extends TestCase
 {
     #[DataProvider('getAnnotationValues')]
     public function testItCallsPluginManagerWithValue(array $values, string $className): void
     {
-        $inject = new InjectViewHelper($values);
+        $injectViewHelper = new InjectViewHelper($values);
 
         $pluginManager = $this->createMock(AbstractPluginManager::class);
 
@@ -41,13 +42,13 @@ class InjectViewHelperTest extends TestCase
             ->with('ViewHelperManager')
             ->willReturn($pluginManager);
 
-        self::assertTrue($inject($container), 'Invoke should return true');
+        self::assertTrue($injectViewHelper($container), 'Invoke should return true');
     }
 
     #[DataProvider('getAnnotationValues')]
     public function testItCallsPluginManagerFromParentServiceLocator(array $values, string $className): void
     {
-        $inject = new InjectViewHelper($values);
+        $injectViewHelper = new InjectViewHelper($values);
 
         $filterManager = $this->createMock(AbstractPluginManager::class);
 
@@ -74,33 +75,31 @@ class InjectViewHelperTest extends TestCase
             ->method('getServiceLocator')
             ->willReturn($container);
 
-        self::assertTrue($inject($pluginManager), 'Invoke should return true');
+        self::assertTrue($injectViewHelper($pluginManager), 'Invoke should return true');
     }
 
-    public static function getAnnotationValues(): array
+    public static function getAnnotationValues(): Iterator
     {
-        return [
+        yield [
             [
-                [
-                    'value' => Service1::class,
-                ],
-                Service1::class,
+                'value' => Service1::class,
             ],
+            Service1::class,
+        ];
+        yield [
             [
-                [
-                    'name' => Service1::class,
-                    'options' => [
-                        'field' => true,
-                    ],
+                'name' => Service1::class,
+                'options' => [
+                    'field' => true,
                 ],
-                Service1::class,
             ],
+            Service1::class,
+        ];
+        yield [
             [
-                [
-                    'name' => Service1::class,
-                ],
-                Service1::class,
+                'name' => Service1::class,
             ],
+            Service1::class,
         ];
     }
 }

--- a/test/Unit/Attribute/AbstractInjectPluginManagerTest.php
+++ b/test/Unit/Attribute/AbstractInjectPluginManagerTest.php
@@ -11,13 +11,13 @@ use Reinfi\DependencyInjection\Test\Service\NoPluginManagerAttribute;
 use Reinfi\DependencyInjection\Test\Service\Service1;
 use Reinfi\DependencyInjection\Test\Service\Service2;
 
-class AbstractInjectPluginManagerTest extends TestCase
+final class AbstractInjectPluginManagerTest extends TestCase
 {
     public function testItThrowsExceptionIfNotInstanceOfPluginManager(): void
     {
         $this->expectException(InjectionNotPossibleException::class);
 
-        $attribute = new NoPluginManagerAttribute(Service1::class);
+        $noPluginManagerAttribute = new NoPluginManagerAttribute(Service1::class);
 
         $noPluginManagerClass = $this->createMock(Service2::class);
 
@@ -26,6 +26,6 @@ class AbstractInjectPluginManagerTest extends TestCase
             ->with('NOT-A-PLUGIN-MANAGER')
             ->willReturn($noPluginManagerClass);
 
-        $attribute($container);
+        $noPluginManagerAttribute($container);
     }
 }

--- a/test/Unit/Attribute/InjectConfigTest.php
+++ b/test/Unit/Attribute/InjectConfigTest.php
@@ -14,11 +14,11 @@ use Reinfi\DependencyInjection\Service\ConfigService;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Attribute
  */
-class InjectConfigTest extends TestCase
+final class InjectConfigTest extends TestCase
 {
     public function testItCallsConfigServiceFromContainerWithValue(): void
     {
-        $inject = new InjectConfig('reinfi.di.test');
+        $injectConfig = new InjectConfig('reinfi.di.test');
 
         $configService = $this->createMock(ConfigService::class);
         $configService->method('resolve')
@@ -30,12 +30,12 @@ class InjectConfigTest extends TestCase
             ->with(ConfigService::class)
             ->willReturn($configService);
 
-        self::assertTrue($inject($container), 'Invoke should return true');
+        self::assertTrue($injectConfig($container), 'Invoke should return true');
     }
 
     public function testItCallsConfigServiceFromPluginManagerWithValue(): void
     {
-        $inject = new InjectConfig('reinfi.di.test');
+        $injectConfig = new InjectConfig('reinfi.di.test');
 
         $configService = $this->createMock(ConfigService::class);
         $configService->method('resolve')
@@ -51,12 +51,12 @@ class InjectConfigTest extends TestCase
         $pluginManager->method('getServiceLocator')
             ->willReturn($container);
 
-        self::assertTrue($inject($pluginManager), 'Invoke should return true');
+        self::assertTrue($injectConfig($pluginManager), 'Invoke should return true');
     }
 
     public function testItReturnsArrayIfPropertyIsSet(): void
     {
-        $inject = new InjectConfig('reinfi.di.test', true);
+        $injectConfig = new InjectConfig('reinfi.di.test', true);
 
         $config = $this->createMock(Config::class);
         $config->expects($this->once())
@@ -73,6 +73,6 @@ class InjectConfigTest extends TestCase
             ->with(ConfigService::class)
             ->willReturn($configService);
 
-        self::assertEquals([true], $inject($container), 'Invoke should return array containing true');
+        self::assertEquals([true], $injectConfig($container), 'Invoke should return array containing true');
     }
 }

--- a/test/Unit/Attribute/InjectConstantTest.php
+++ b/test/Unit/Attribute/InjectConstantTest.php
@@ -13,17 +13,17 @@ use Reinfi\DependencyInjection\Test\Service\Service2;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Attribute
  */
-class InjectConstantTest extends TestCase
+final class InjectConstantTest extends TestCase
 {
     public function testItShouldConvertScalarTypes(): void
     {
-        $injectScalar = new InjectConstant(Service2::class . '::CONSTANT');
+        $injectConstant = new InjectConstant(Service2::class . '::CONSTANT');
 
         $container = $this->createMock(ContainerInterface::class);
         $container->method('get')
             ->with(InjectionService::class)
             ->willReturn(true);
 
-        self::assertSame(Service2::CONSTANT, $injectScalar($container));
+        self::assertSame(Service2::CONSTANT, $injectConstant($container));
     }
 }

--- a/test/Unit/Attribute/InjectContainerTest.php
+++ b/test/Unit/Attribute/InjectContainerTest.php
@@ -11,14 +11,14 @@ use Reinfi\DependencyInjection\Attribute\InjectContainer;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Attribute
  */
-class InjectContainerTest extends TestCase
+final class InjectContainerTest extends TestCase
 {
     public function testItCallsContainerWithValue(): void
     {
-        $inject = new InjectContainer();
+        $injectContainer = new InjectContainer();
 
         $container = $this->createMock(ContainerInterface::class);
 
-        self::assertEquals($container, $inject($container), 'Invoke should return provided container');
+        self::assertEquals($container, $injectContainer($container), 'Invoke should return provided container');
     }
 }

--- a/test/Unit/Attribute/InjectControllerPluginTest.php
+++ b/test/Unit/Attribute/InjectControllerPluginTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Reinfi\DependencyInjection\Test\Unit\Attribute;
 
+use Iterator;
 use Laminas\ServiceManager\AbstractPluginManager;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -14,12 +15,12 @@ use Reinfi\DependencyInjection\Test\Service\Service1;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Attribute
  */
-class InjectControllerPluginTest extends TestCase
+final class InjectControllerPluginTest extends TestCase
 {
     #[DataProvider('getAttributeValues')]
     public function testItCallsPluginManagerWithValue(array $values, string $className): void
     {
-        $inject = new InjectControllerPlugin(...array_values($values));
+        $injectControllerPlugin = new InjectControllerPlugin(...array_values($values));
 
         $pluginManager = $this->createMock(AbstractPluginManager::class);
 
@@ -41,13 +42,13 @@ class InjectControllerPluginTest extends TestCase
             ->with('ControllerPluginManager')
             ->willReturn($pluginManager);
 
-        self::assertTrue($inject($container), 'Invoke should return true');
+        self::assertTrue($injectControllerPlugin($container), 'Invoke should return true');
     }
 
     #[DataProvider('getAttributeValues')]
     public function testItCallsPluginManagerFromParentServiceLocator(array $values, string $className): void
     {
-        $inject = new InjectControllerPlugin(...array_values($values));
+        $injectControllerPlugin = new InjectControllerPlugin(...array_values($values));
 
         $filterManager = $this->createMock(AbstractPluginManager::class);
 
@@ -74,27 +75,25 @@ class InjectControllerPluginTest extends TestCase
             ->method('getServiceLocator')
             ->willReturn($container);
 
-        self::assertTrue($inject($pluginManager), 'Invoke should return true');
+        self::assertTrue($injectControllerPlugin($pluginManager), 'Invoke should return true');
     }
 
-    public static function getAttributeValues(): array
+    public static function getAttributeValues(): Iterator
     {
-        return [
+        yield [
             [
-                [
-                    'name' => Service1::class,
-                ],
-                Service1::class,
+                'name' => Service1::class,
             ],
+            Service1::class,
+        ];
+        yield [
             [
-                [
-                    'name' => Service1::class,
-                    'options' => [
-                        'field' => true,
-                    ],
+                'name' => Service1::class,
+                'options' => [
+                    'field' => true,
                 ],
-                Service1::class,
             ],
+            Service1::class,
         ];
     }
 }

--- a/test/Unit/Attribute/InjectDoctrineRepositoryTest.php
+++ b/test/Unit/Attribute/InjectDoctrineRepositoryTest.php
@@ -6,6 +6,7 @@ namespace Reinfi\DependencyInjection\Test\Unit\Attribute;
 
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityRepository;
+use Iterator;
 use Laminas\ServiceManager\AbstractPluginManager;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -17,20 +18,20 @@ use Reinfi\DependencyInjection\Test\Service\Service2;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Attribute
  */
-class InjectDoctrineRepositoryTest extends TestCase
+final class InjectDoctrineRepositoryTest extends TestCase
 {
     #[DataProvider('getAttributeValuesWithoutEntityManager')]
     public function testItGetsRepositoryWithoutEntityManagerSet(array $values, string $repositoryClass): void
     {
-        $inject = new InjectDoctrineRepository(...array_values($values));
+        $injectDoctrineRepository = new InjectDoctrineRepository(...array_values($values));
 
-        $repository = $this->createMock($repositoryClass);
+        $mockObject = $this->createMock($repositoryClass);
 
         $entityManager = $this->createMock(EntityManager::class);
         $entityManager->expects($this->once())
             ->method('getRepository')
             ->with($repositoryClass)
-            ->willReturn($repository);
+            ->willReturn($mockObject);
 
         $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->once())
@@ -40,7 +41,7 @@ class InjectDoctrineRepositoryTest extends TestCase
 
         self::assertInstanceOf(
             $repositoryClass,
-            $inject($container),
+            $injectDoctrineRepository($container),
             'Should be instance of repositoryClass ' . $repositoryClass
         );
     }
@@ -51,15 +52,15 @@ class InjectDoctrineRepositoryTest extends TestCase
         string $entityManagerIdentifier,
         string $repositoryClass
     ): void {
-        $inject = new InjectDoctrineRepository(...array_values($values));
+        $injectDoctrineRepository = new InjectDoctrineRepository(...array_values($values));
 
-        $repository = $this->createMock($repositoryClass);
+        $mockObject = $this->createMock($repositoryClass);
 
         $entityManager = $this->createMock(EntityManager::class);
         $entityManager->expects($this->once())
             ->method('getRepository')
             ->with($repositoryClass)
-            ->willReturn($repository);
+            ->willReturn($mockObject);
 
         $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->once())
@@ -69,7 +70,7 @@ class InjectDoctrineRepositoryTest extends TestCase
 
         self::assertInstanceOf(
             $repositoryClass,
-            $inject($container),
+            $injectDoctrineRepository($container),
             'Should be instance of repositoryClass ' . $repositoryClass
         );
     }
@@ -77,15 +78,15 @@ class InjectDoctrineRepositoryTest extends TestCase
     #[DataProvider('getAttributeValuesWithoutEntityManager')]
     public function testItGetsRepositoryFromPluginManager(array $values, string $repositoryClass): void
     {
-        $inject = new InjectDoctrineRepository(...array_values($values));
+        $injectDoctrineRepository = new InjectDoctrineRepository(...array_values($values));
 
-        $repository = $this->createMock($repositoryClass);
+        $mockObject = $this->createMock($repositoryClass);
 
         $entityManager = $this->createMock(EntityManager::class);
         $entityManager->expects($this->once())
             ->method('getRepository')
             ->with($repositoryClass)
-            ->willReturn($repository);
+            ->willReturn($mockObject);
 
         $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->once())
@@ -100,34 +101,30 @@ class InjectDoctrineRepositoryTest extends TestCase
 
         self::assertInstanceOf(
             $repositoryClass,
-            $inject($pluginManager),
+            $injectDoctrineRepository($pluginManager),
             'Should be instance of repositoryClass ' . $repositoryClass
         );
     }
 
-    public static function getAttributeValuesWithoutEntityManager(): array
+    public static function getAttributeValuesWithoutEntityManager(): Iterator
     {
-        return [
+        yield [
             [
-                [
-                    'entity' => EntityRepository::class,
-                ],
-                EntityRepository::class,
+                'entity' => EntityRepository::class,
             ],
+            EntityRepository::class,
         ];
     }
 
-    public static function getAttributeValuesWithEntityManager(): array
+    public static function getAttributeValuesWithEntityManager(): Iterator
     {
-        return [
+        yield [
             [
-                [
-                    'entity' => EntityRepository::class,
-                    'entityManager' => 'doctrine.entityManager',
-                ],
-                'doctrine.entityManager',
-                EntityRepository::class,
+                'entity' => EntityRepository::class,
+                'entityManager' => 'doctrine.entityManager',
             ],
+            'doctrine.entityManager',
+            EntityRepository::class,
         ];
     }
 
@@ -135,7 +132,7 @@ class InjectDoctrineRepositoryTest extends TestCase
     {
         $this->expectException(AutoWiringNotPossibleException::class);
 
-        $inject = new InjectDoctrineRepository(EntityRepository::class, 'No-EntityManager');
+        $injectDoctrineRepository = new InjectDoctrineRepository(EntityRepository::class, 'No-EntityManager');
 
         $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->once())
@@ -143,14 +140,14 @@ class InjectDoctrineRepositoryTest extends TestCase
             ->with('No-EntityManager')
             ->willReturn('1');
 
-        $inject($container);
+        $injectDoctrineRepository($container);
     }
 
     public function testItThrowsExceptionIfEntityManagerHasNotGetRepositoryMethod(): void
     {
         $this->expectException(AutoWiringNotPossibleException::class);
 
-        $inject = new InjectDoctrineRepository(EntityRepository::class, 'No-EntityManager');
+        $injectDoctrineRepository = new InjectDoctrineRepository(EntityRepository::class, 'No-EntityManager');
 
         $service2 = $this->createMock(Service2::class);
         $container = $this->createMock(ContainerInterface::class);
@@ -159,6 +156,6 @@ class InjectDoctrineRepositoryTest extends TestCase
             ->with('No-EntityManager')
             ->willReturn($service2);
 
-        $inject($container);
+        $injectDoctrineRepository($container);
     }
 }

--- a/test/Unit/Attribute/InjectFilterTest.php
+++ b/test/Unit/Attribute/InjectFilterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Reinfi\DependencyInjection\Test\Unit\Attribute;
 
+use Iterator;
 use Laminas\ServiceManager\AbstractPluginManager;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -14,12 +15,12 @@ use Reinfi\DependencyInjection\Test\Service\Service1;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Attribute
  */
-class InjectFilterTest extends TestCase
+final class InjectFilterTest extends TestCase
 {
     #[DataProvider('getAttributeValues')]
     public function testItCallsPluginManagerWithValue(array $values, string $className): void
     {
-        $inject = new InjectFilter(...array_values($values));
+        $injectFilter = new InjectFilter(...array_values($values));
 
         $pluginManager = $this->createMock(AbstractPluginManager::class);
 
@@ -41,13 +42,13 @@ class InjectFilterTest extends TestCase
             ->with('FilterManager')
             ->willReturn($pluginManager);
 
-        self::assertTrue($inject($container), 'Invoke should return true');
+        self::assertTrue($injectFilter($container), 'Invoke should return true');
     }
 
     #[DataProvider('getAttributeValues')]
     public function testItCallsPluginManagerFromParentServiceLocator(array $values, string $className): void
     {
-        $inject = new InjectFilter(...array_values($values));
+        $injectFilter = new InjectFilter(...array_values($values));
 
         $filterManager = $this->createMock(AbstractPluginManager::class);
 
@@ -74,27 +75,25 @@ class InjectFilterTest extends TestCase
             ->method('getServiceLocator')
             ->willReturn($container);
 
-        self::assertTrue($inject($pluginManager), 'Invoke should return true');
+        self::assertTrue($injectFilter($pluginManager), 'Invoke should return true');
     }
 
-    public static function getAttributeValues(): array
+    public static function getAttributeValues(): Iterator
     {
-        return [
+        yield [
             [
-                [
-                    'name' => Service1::class,
-                ],
-                Service1::class,
+                'name' => Service1::class,
             ],
+            Service1::class,
+        ];
+        yield [
             [
-                [
-                    'name' => Service1::class,
-                    'options' => [
-                        'field' => true,
-                    ],
+                'name' => Service1::class,
+                'options' => [
+                    'field' => true,
                 ],
-                Service1::class,
             ],
+            Service1::class,
         ];
     }
 }

--- a/test/Unit/Attribute/InjectFormElementTest.php
+++ b/test/Unit/Attribute/InjectFormElementTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Reinfi\DependencyInjection\Test\Unit\Attribute;
 
+use Iterator;
 use Laminas\ServiceManager\AbstractPluginManager;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -14,12 +15,12 @@ use Reinfi\DependencyInjection\Test\Service\Service1;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Attribute
  */
-class InjectFormElementTest extends TestCase
+final class InjectFormElementTest extends TestCase
 {
     #[DataProvider('getAttributeValues')]
     public function testItCallsPluginManagerWithValue(array $values, string $className): void
     {
-        $inject = new InjectFormElement(...array_values($values));
+        $injectFormElement = new InjectFormElement(...array_values($values));
 
         $pluginManager = $this->createMock(AbstractPluginManager::class);
 
@@ -41,13 +42,13 @@ class InjectFormElementTest extends TestCase
             ->with('FormElementManager')
             ->willReturn($pluginManager);
 
-        self::assertTrue($inject($container), 'Invoke should return true');
+        self::assertTrue($injectFormElement($container), 'Invoke should return true');
     }
 
     #[DataProvider('getAttributeValues')]
     public function testItCallsPluginManagerFromParentServiceLocator(array $values, string $className): void
     {
-        $inject = new InjectFormElement(...array_values($values));
+        $injectFormElement = new InjectFormElement(...array_values($values));
 
         $filterManager = $this->createMock(AbstractPluginManager::class);
 
@@ -74,27 +75,25 @@ class InjectFormElementTest extends TestCase
             ->method('getServiceLocator')
             ->willReturn($container);
 
-        self::assertTrue($inject($pluginManager), 'Invoke should return true');
+        self::assertTrue($injectFormElement($pluginManager), 'Invoke should return true');
     }
 
-    public static function getAttributeValues(): array
+    public static function getAttributeValues(): Iterator
     {
-        return [
+        yield [
             [
-                [
-                    'name' => Service1::class,
-                ],
-                Service1::class,
+                'name' => Service1::class,
             ],
+            Service1::class,
+        ];
+        yield [
             [
-                [
-                    'name' => Service1::class,
-                    'options' => [
-                        'field' => true,
-                    ],
+                'name' => Service1::class,
+                'options' => [
+                    'field' => true,
                 ],
-                Service1::class,
             ],
+            Service1::class,
         ];
     }
 }

--- a/test/Unit/Attribute/InjectHydratorTest.php
+++ b/test/Unit/Attribute/InjectHydratorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Reinfi\DependencyInjection\Test\Unit\Attribute;
 
+use Iterator;
 use Laminas\ServiceManager\AbstractPluginManager;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -14,12 +15,12 @@ use Reinfi\DependencyInjection\Test\Service\Service1;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Attribute
  */
-class InjectHydratorTest extends TestCase
+final class InjectHydratorTest extends TestCase
 {
     #[DataProvider('getAttributeValues')]
     public function testItCallsPluginManagerWithValue(array $values, string $className): void
     {
-        $inject = new InjectHydrator(...array_values($values));
+        $injectHydrator = new InjectHydrator(...array_values($values));
 
         $pluginManager = $this->createMock(AbstractPluginManager::class);
 
@@ -41,13 +42,13 @@ class InjectHydratorTest extends TestCase
             ->with('HydratorManager')
             ->willReturn($pluginManager);
 
-        self::assertTrue($inject($container), 'Invoke should return true');
+        self::assertTrue($injectHydrator($container), 'Invoke should return true');
     }
 
     #[DataProvider('getAttributeValues')]
     public function testItCallsPluginManagerFromParentServiceLocator(array $values, string $className): void
     {
-        $inject = new InjectHydrator(...array_values($values));
+        $injectHydrator = new InjectHydrator(...array_values($values));
 
         $filterManager = $this->createMock(AbstractPluginManager::class);
 
@@ -74,27 +75,25 @@ class InjectHydratorTest extends TestCase
             ->method('getServiceLocator')
             ->willReturn($container);
 
-        self::assertTrue($inject($pluginManager), 'Invoke should return true');
+        self::assertTrue($injectHydrator($pluginManager), 'Invoke should return true');
     }
 
-    public static function getAttributeValues(): array
+    public static function getAttributeValues(): Iterator
     {
-        return [
+        yield [
             [
-                [
-                    'name' => Service1::class,
-                ],
-                Service1::class,
+                'name' => Service1::class,
             ],
+            Service1::class,
+        ];
+        yield [
             [
-                [
-                    'name' => Service1::class,
-                    'options' => [
-                        'field' => true,
-                    ],
+                'name' => Service1::class,
+                'options' => [
+                    'field' => true,
                 ],
-                Service1::class,
             ],
+            Service1::class,
         ];
     }
 }

--- a/test/Unit/Attribute/InjectInputFilterTest.php
+++ b/test/Unit/Attribute/InjectInputFilterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Reinfi\DependencyInjection\Test\Unit\Attribute;
 
+use Iterator;
 use Laminas\ServiceManager\AbstractPluginManager;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -14,12 +15,12 @@ use Reinfi\DependencyInjection\Test\Service\Service1;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Attribute
  */
-class InjectInputFilterTest extends TestCase
+final class InjectInputFilterTest extends TestCase
 {
     #[DataProvider('getAttributeValues')]
     public function testItCallsPluginManagerWithValue(array $values, string $className): void
     {
-        $inject = new InjectInputFilter(...array_values($values));
+        $injectInputFilter = new InjectInputFilter(...array_values($values));
 
         $pluginManager = $this->createMock(AbstractPluginManager::class);
 
@@ -41,13 +42,13 @@ class InjectInputFilterTest extends TestCase
             ->with('InputFilterManager')
             ->willReturn($pluginManager);
 
-        self::assertTrue($inject($container), 'Invoke should return true');
+        self::assertTrue($injectInputFilter($container), 'Invoke should return true');
     }
 
     #[DataProvider('getAttributeValues')]
     public function testItCallsPluginManagerFromParentServiceLocator(array $values, string $className): void
     {
-        $inject = new InjectInputFilter(...array_values($values));
+        $injectInputFilter = new InjectInputFilter(...array_values($values));
 
         $filterManager = $this->createMock(AbstractPluginManager::class);
 
@@ -74,27 +75,25 @@ class InjectInputFilterTest extends TestCase
             ->method('getServiceLocator')
             ->willReturn($container);
 
-        self::assertTrue($inject($pluginManager), 'Invoke should return true');
+        self::assertTrue($injectInputFilter($pluginManager), 'Invoke should return true');
     }
 
-    public static function getAttributeValues(): array
+    public static function getAttributeValues(): Iterator
     {
-        return [
+        yield [
             [
-                [
-                    'name' => Service1::class,
-                ],
-                Service1::class,
+                'name' => Service1::class,
             ],
+            Service1::class,
+        ];
+        yield [
             [
-                [
-                    'name' => Service1::class,
-                    'options' => [
-                        'field' => true,
-                    ],
+                'name' => Service1::class,
+                'options' => [
+                    'field' => true,
                 ],
-                Service1::class,
             ],
+            Service1::class,
         ];
     }
 }

--- a/test/Unit/Attribute/InjectParentTest.php
+++ b/test/Unit/Attribute/InjectParentTest.php
@@ -13,23 +13,23 @@ use Reinfi\DependencyInjection\Service\InjectionService;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Attribute
  */
-class InjectParentTest extends TestCase
+final class InjectParentTest extends TestCase
 {
     public function testItCallsContainerWithValue(): void
     {
-        $inject = new InjectParent(InjectionService::class);
+        $injectParent = new InjectParent(InjectionService::class);
 
         $container = $this->createMock(ContainerInterface::class);
         $container->method('get')
             ->with(InjectionService::class)
             ->willReturn(true);
 
-        self::assertTrue($inject($container), 'Invoke should return true');
+        self::assertTrue($injectParent($container), 'Invoke should return true');
     }
 
     public function testItCallsParentContainerWhenPluginManager(): void
     {
-        $inject = new InjectParent(InjectionService::class);
+        $injectParent = new InjectParent(InjectionService::class);
 
         $container = $this->createMock(ContainerInterface::class);
         $container->method('get')
@@ -40,6 +40,6 @@ class InjectParentTest extends TestCase
         $pluginManager->method('getServiceLocator')
             ->willReturn($container);
 
-        self::assertTrue($inject($pluginManager), 'Invoke should return true');
+        self::assertTrue($injectParent($pluginManager), 'Invoke should return true');
     }
 }

--- a/test/Unit/Attribute/InjectTest.php
+++ b/test/Unit/Attribute/InjectTest.php
@@ -12,7 +12,7 @@ use Reinfi\DependencyInjection\Service\InjectionService;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Attribute
  */
-class InjectTest extends TestCase
+final class InjectTest extends TestCase
 {
     public function testItCallsContainerWithValue(): void
     {

--- a/test/Unit/Attribute/InjectValidatorTest.php
+++ b/test/Unit/Attribute/InjectValidatorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Reinfi\DependencyInjection\Test\Unit\Attribute;
 
+use Iterator;
 use Laminas\ServiceManager\AbstractPluginManager;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -14,12 +15,12 @@ use Reinfi\DependencyInjection\Test\Service\Service1;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Attribute
  */
-class InjectValidatorTest extends TestCase
+final class InjectValidatorTest extends TestCase
 {
     #[DataProvider('getAttributeValues')]
     public function testItCallsPluginManagerWithValue(array $values, string $className): void
     {
-        $inject = new InjectValidator(...array_values($values));
+        $injectValidator = new InjectValidator(...array_values($values));
 
         $pluginManager = $this->createMock(AbstractPluginManager::class);
 
@@ -41,13 +42,13 @@ class InjectValidatorTest extends TestCase
             ->with('ValidatorManager')
             ->willReturn($pluginManager);
 
-        self::assertTrue($inject($container), 'Invoke should return true');
+        self::assertTrue($injectValidator($container), 'Invoke should return true');
     }
 
     #[DataProvider('getAttributeValues')]
     public function testItCallsPluginManagerFromParentServiceLocator(array $values, string $className): void
     {
-        $inject = new InjectValidator(...array_values($values));
+        $injectValidator = new InjectValidator(...array_values($values));
 
         $filterManager = $this->createMock(AbstractPluginManager::class);
 
@@ -74,27 +75,25 @@ class InjectValidatorTest extends TestCase
             ->method('getServiceLocator')
             ->willReturn($container);
 
-        self::assertTrue($inject($pluginManager), 'Invoke should return true');
+        self::assertTrue($injectValidator($pluginManager), 'Invoke should return true');
     }
 
-    public static function getAttributeValues(): array
+    public static function getAttributeValues(): Iterator
     {
-        return [
+        yield [
             [
-                [
-                    'name' => Service1::class,
-                ],
-                Service1::class,
+                'name' => Service1::class,
             ],
+            Service1::class,
+        ];
+        yield [
             [
-                [
-                    'name' => Service1::class,
-                    'options' => [
-                        'field' => true,
-                    ],
+                'name' => Service1::class,
+                'options' => [
+                    'field' => true,
                 ],
-                Service1::class,
             ],
+            Service1::class,
         ];
     }
 }

--- a/test/Unit/Attribute/InjectViewHelperTest.php
+++ b/test/Unit/Attribute/InjectViewHelperTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Reinfi\DependencyInjection\Test\Unit\Attribute;
 
+use Iterator;
 use Laminas\ServiceManager\AbstractPluginManager;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -14,12 +15,12 @@ use Reinfi\DependencyInjection\Test\Service\Service1;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Attribute
  */
-class InjectViewHelperTest extends TestCase
+final class InjectViewHelperTest extends TestCase
 {
     #[DataProvider('getAttributeValues')]
     public function testItCallsPluginManagerWithValue(array $values, string $className): void
     {
-        $inject = new InjectViewHelper(...array_values($values));
+        $injectViewHelper = new InjectViewHelper(...array_values($values));
 
         $pluginManager = $this->createMock(AbstractPluginManager::class);
 
@@ -41,13 +42,13 @@ class InjectViewHelperTest extends TestCase
             ->with('ViewHelperManager')
             ->willReturn($pluginManager);
 
-        self::assertTrue($inject($container), 'Invoke should return true');
+        self::assertTrue($injectViewHelper($container), 'Invoke should return true');
     }
 
     #[DataProvider('getAttributeValues')]
     public function testItCallsPluginManagerFromParentServiceLocator(array $values, string $className): void
     {
-        $inject = new InjectViewHelper(...array_values($values));
+        $injectViewHelper = new InjectViewHelper(...array_values($values));
 
         $filterManager = $this->createMock(AbstractPluginManager::class);
 
@@ -74,27 +75,25 @@ class InjectViewHelperTest extends TestCase
             ->method('getServiceLocator')
             ->willReturn($container);
 
-        self::assertTrue($inject($pluginManager), 'Invoke should return true');
+        self::assertTrue($injectViewHelper($pluginManager), 'Invoke should return true');
     }
 
-    public static function getAttributeValues(): array
+    public static function getAttributeValues(): Iterator
     {
-        return [
+        yield [
             [
-                [
-                    'name' => Service1::class,
-                ],
-                Service1::class,
+                'name' => Service1::class,
             ],
+            Service1::class,
+        ];
+        yield [
             [
-                [
-                    'name' => Service1::class,
-                    'options' => [
-                        'field' => true,
-                    ],
+                'name' => Service1::class,
+                'options' => [
+                    'field' => true,
                 ],
-                Service1::class,
             ],
+            Service1::class,
         ];
     }
 }

--- a/test/Unit/Config/Factory/ModuleConfigFactoryTest.php
+++ b/test/Unit/Config/Factory/ModuleConfigFactoryTest.php
@@ -13,11 +13,11 @@ use Reinfi\DependencyInjection\Config\ModuleConfig;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Config\Factory
  */
-class ModuleConfigFactoryTest extends TestCase
+final class ModuleConfigFactoryTest extends TestCase
 {
     public function testItReturnsModuleConfig(): void
     {
-        $factory = new ModuleConfigFactory();
+        $moduleConfigFactory = new ModuleConfigFactory();
 
         $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->once())
@@ -27,12 +27,12 @@ class ModuleConfigFactoryTest extends TestCase
                 ModuleConfig::CONFIG_KEY => [],
             ]);
 
-        self::assertIsArray($factory($container), 'Factory should return array');
+        self::assertIsArray($moduleConfigFactory($container), 'Factory should return array');
     }
 
     public function testItReturnsModuleConfigData(): void
     {
-        $factory = new ModuleConfigFactory();
+        $moduleConfigFactory = new ModuleConfigFactory();
 
         $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->once())
@@ -44,14 +44,14 @@ class ModuleConfigFactoryTest extends TestCase
                 ],
             ]);
 
-        $config = $factory($container);
+        $config = $moduleConfigFactory($container);
 
         self::assertArrayHasKey('extractor', $config, 'Config should contain extractor key');
     }
 
     public function testItReturnsEmptyConfig(): void
     {
-        $factory = new ModuleConfigFactory();
+        $moduleConfigFactory = new ModuleConfigFactory();
 
         $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->once())
@@ -59,7 +59,7 @@ class ModuleConfigFactoryTest extends TestCase
             ->with('config')
             ->willReturn([]);
 
-        $config = $factory($container);
+        $config = $moduleConfigFactory($container);
 
         self::assertCount(0, $config, 'Config should be empty');
     }
@@ -68,7 +68,7 @@ class ModuleConfigFactoryTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $factory = new ModuleConfigFactory();
+        $moduleConfigFactory = new ModuleConfigFactory();
 
         $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->once())
@@ -78,6 +78,6 @@ class ModuleConfigFactoryTest extends TestCase
                 ModuleConfig::CONFIG_KEY => true,
             ]);
 
-        $factory($container);
+        $moduleConfigFactory($container);
     }
 }

--- a/test/Unit/ConfigProviderTest.php
+++ b/test/Unit/ConfigProviderTest.php
@@ -7,7 +7,7 @@ namespace Reinfi\DependencyInjection\Test\Unit;
 use PHPUnit\Framework\TestCase;
 use Reinfi\DependencyInjection\ConfigProvider;
 
-class ConfigProviderTest extends TestCase
+final class ConfigProviderTest extends TestCase
 {
     public function testItReturnsDependencies(): void
     {

--- a/test/Unit/Extension/PHPStan/Resolve/AutoWiringClassesResolverTest.php
+++ b/test/Unit/Extension/PHPStan/Resolve/AutoWiringClassesResolverTest.php
@@ -10,25 +10,25 @@ use Reinfi\DependencyInjection\Extension\PHPStan\ServiceManagerLoader;
 use Reinfi\DependencyInjection\Test\Service\Service1;
 use Reinfi\DependencyInjection\Test\Service\Service2;
 
-class AutoWiringClassesResolverTest extends TestCase
+final class AutoWiringClassesResolverTest extends TestCase
 {
     public function testItReturnsFalseIfNoServiceManagerIsProvided(): void
     {
         $serviceManagerLoader = new ServiceManagerLoader(null);
 
-        $classesResolver = new AutoWiringClassesResolver($serviceManagerLoader);
+        $autoWiringClassesResolver = new AutoWiringClassesResolver($serviceManagerLoader);
 
-        self::assertFalse($classesResolver->isAutowired(Service1::class));
+        self::assertFalse($autoWiringClassesResolver->isAutowired(Service1::class));
     }
 
     public function testItReturnsTrueIfClassIsRegisteredForAutoWiring(): void
     {
         $serviceManagerLoader = new ServiceManagerLoader(__DIR__ . '/../../../../resources/container.php');
 
-        $classesResolver = new AutoWiringClassesResolver($serviceManagerLoader);
+        $autoWiringClassesResolver = new AutoWiringClassesResolver($serviceManagerLoader);
 
-        self::assertTrue($classesResolver->isAutowired(Service1::class));
+        self::assertTrue($autoWiringClassesResolver->isAutowired(Service1::class));
 
-        self::assertFalse($classesResolver->isAutowired(Service2::class));
+        self::assertFalse($autoWiringClassesResolver->isAutowired(Service2::class));
     }
 }

--- a/test/Unit/Factory/AutoWiringFactoryTest.php
+++ b/test/Unit/Factory/AutoWiringFactoryTest.php
@@ -18,18 +18,14 @@ use Reinfi\DependencyInjection\Test\Service\Service3;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Factory
  */
-class AutoWiringFactoryTest extends TestCase
+final class AutoWiringFactoryTest extends TestCase
 {
     public function testItCreatesServiceWithInjections(): void
     {
         $service = $this->createMock(AutoWiringService::class);
         $service->expects($this->once())
             ->method('resolveConstructorInjection')
-            ->with(
-                $this->isInstanceOf(ContainerInterface::class),
-                $this->equalTo(Service1::class),
-                $this->equalTo(null)
-            )
+            ->with($this->isInstanceOf(ContainerInterface::class), Service1::class, null)
             ->willReturn([new Service2(), new Service3()]);
 
         $container = $this->createMock(ServiceLocatorInterface::class);
@@ -38,9 +34,9 @@ class AutoWiringFactoryTest extends TestCase
             ->with(AutoWiringService::class)
             ->willReturn($service);
 
-        $factory = new AutoWiringFactory();
+        $autoWiringFactory = new AutoWiringFactory();
 
-        $instance = $factory->createService($container, Service1::class, Service1::class);
+        $instance = $autoWiringFactory->createService($container, Service1::class, Service1::class);
 
         self::assertInstanceOf(Service1::class, $instance);
     }
@@ -53,11 +49,7 @@ class AutoWiringFactoryTest extends TestCase
         $service = $this->createMock(AutoWiringService::class);
         $service->expects($this->once())
             ->method('resolveConstructorInjection')
-            ->with(
-                $this->isInstanceOf(ContainerInterface::class),
-                $this->equalTo(Service1::class),
-                $this->equalTo($options)
-            )
+            ->with($this->isInstanceOf(ContainerInterface::class), Service1::class, $options)
             ->willReturn([new Service2(), new Service3()]);
 
         $container = $this->createMock(ServiceLocatorInterface::class);
@@ -66,9 +58,9 @@ class AutoWiringFactoryTest extends TestCase
             ->with(AutoWiringService::class)
             ->willReturn($service);
 
-        $factory = new AutoWiringFactory();
+        $autoWiringFactory = new AutoWiringFactory();
 
-        $instance = $factory($container, Service1::class, $options);
+        $instance = $autoWiringFactory($container, Service1::class, $options);
 
         self::assertInstanceOf(Service1::class, $instance);
     }
@@ -78,11 +70,7 @@ class AutoWiringFactoryTest extends TestCase
         $service = $this->createMock(AutoWiringService::class);
         $service->expects($this->once())
             ->method('resolveConstructorInjection')
-            ->with(
-                $this->isInstanceOf(ContainerInterface::class),
-                $this->equalTo(Service1::class),
-                $this->equalTo(null)
-            )
+            ->with($this->isInstanceOf(ContainerInterface::class), Service1::class, null)
             ->willReturn([new Service2(), new Service3()]);
 
         $container = $this->createMock(ServiceLocatorInterface::class);
@@ -91,9 +79,9 @@ class AutoWiringFactoryTest extends TestCase
             ->with(AutoWiringService::class)
             ->willReturn($service);
 
-        $factory = new AutoWiringFactory();
+        $autoWiringFactory = new AutoWiringFactory();
 
-        $instance = $factory->createService($container, Service1::class);
+        $instance = $autoWiringFactory->createService($container, Service1::class);
 
         self::assertInstanceOf(Service1::class, $instance);
     }
@@ -103,11 +91,7 @@ class AutoWiringFactoryTest extends TestCase
         $service = $this->createMock(AutoWiringService::class);
         $service->expects($this->once())
             ->method('resolveConstructorInjection')
-            ->with(
-                $this->isInstanceOf(ContainerInterface::class),
-                $this->equalTo(Service1::class),
-                $this->equalTo(null)
-            )
+            ->with($this->isInstanceOf(ContainerInterface::class), Service1::class, null)
             ->willReturn([new Service2(), new Service3()]);
 
         $container = $this->createMock(ServiceLocatorInterface::class);
@@ -121,9 +105,9 @@ class AutoWiringFactoryTest extends TestCase
             ->method('getServiceLocator')
             ->willReturn($container);
 
-        $factory = new AutoWiringFactory();
+        $autoWiringFactory = new AutoWiringFactory();
 
-        $instance = $factory->createService($pluginManager, Service1::class);
+        $instance = $autoWiringFactory->createService($pluginManager, Service1::class);
 
         self::assertInstanceOf(Service1::class, $instance);
     }
@@ -133,11 +117,7 @@ class AutoWiringFactoryTest extends TestCase
         $service = $this->createMock(AutoWiringService::class);
         $service->expects($this->once())
             ->method('resolveConstructorInjection')
-            ->with(
-                $this->isInstanceOf(ContainerInterface::class),
-                $this->equalTo(Service2::class),
-                $this->equalTo(null)
-            )
+            ->with($this->isInstanceOf(ContainerInterface::class), Service2::class, null)
             ->willReturn(null);
 
         $container = $this->createMock(ServiceLocatorInterface::class);
@@ -146,9 +126,9 @@ class AutoWiringFactoryTest extends TestCase
             ->with(AutoWiringService::class)
             ->willReturn($service);
 
-        $factory = new AutoWiringFactory();
+        $autoWiringFactory = new AutoWiringFactory();
 
-        $instance = $factory->createService($container, Service2::class);
+        $instance = $autoWiringFactory->createService($container, Service2::class);
 
         self::assertInstanceOf(Service2::class, $instance);
     }
@@ -159,9 +139,9 @@ class AutoWiringFactoryTest extends TestCase
 
         $container = $this->createMock(ServiceLocatorInterface::class);
 
-        $factory = new AutoWiringFactory();
+        $autoWiringFactory = new AutoWiringFactory();
 
-        $factory->createService($container);
+        $autoWiringFactory->createService($container);
     }
 
     public function testItThrowsExceptionIfClassNotFound(): void
@@ -170,8 +150,8 @@ class AutoWiringFactoryTest extends TestCase
 
         $container = $this->createMock(ServiceLocatorInterface::class);
 
-        $factory = new AutoWiringFactory();
+        $autoWiringFactory = new AutoWiringFactory();
 
-        $factory->createService($container, 'No\Existing\ClassName', 'No\Existing\ClassName');
+        $autoWiringFactory->createService($container, 'No\Existing\ClassName', 'No\Existing\ClassName');
     }
 }

--- a/test/Unit/Factory/InjectionFactoryTest.php
+++ b/test/Unit/Factory/InjectionFactoryTest.php
@@ -18,14 +18,14 @@ use Reinfi\DependencyInjection\Test\Service\Service3;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Factory
  */
-class InjectionFactoryTest extends TestCase
+final class InjectionFactoryTest extends TestCase
 {
     public function testItCreatesServiceWithInjections(): void
     {
         $service = $this->createMock(InjectionService::class);
         $service->expects($this->once())
             ->method('resolveConstructorInjection')
-            ->with($this->isInstanceOf(ContainerInterface::class), $this->equalTo(Service1::class))
+            ->with($this->isInstanceOf(ContainerInterface::class), Service1::class)
             ->willReturn([new Service2(), new Service3()]);
 
         $container = $this->createMock(ServiceLocatorInterface::class);
@@ -34,9 +34,9 @@ class InjectionFactoryTest extends TestCase
             ->with(InjectionService::class)
             ->willReturn($service);
 
-        $factory = new InjectionFactory();
+        $injectionFactory = new InjectionFactory();
 
-        $instance = $factory->createService($container, Service1::class, Service1::class);
+        $instance = $injectionFactory->createService($container, Service1::class, Service1::class);
 
         self::assertInstanceOf(Service1::class, $instance);
     }
@@ -46,7 +46,7 @@ class InjectionFactoryTest extends TestCase
         $service = $this->createMock(InjectionService::class);
         $service->expects($this->once())
             ->method('resolveConstructorInjection')
-            ->with($this->isInstanceOf(ContainerInterface::class), $this->equalTo(Service1::class))
+            ->with($this->isInstanceOf(ContainerInterface::class), Service1::class)
             ->willReturn([new Service2(), new Service3()]);
 
         $container = $this->createMock(ServiceLocatorInterface::class);
@@ -55,9 +55,9 @@ class InjectionFactoryTest extends TestCase
             ->with(InjectionService::class)
             ->willReturn($service);
 
-        $factory = new InjectionFactory();
+        $injectionFactory = new InjectionFactory();
 
-        $instance = $factory->createService($container, Service1::class);
+        $instance = $injectionFactory->createService($container, Service1::class);
 
         self::assertInstanceOf(Service1::class, $instance);
     }
@@ -67,7 +67,7 @@ class InjectionFactoryTest extends TestCase
         $service = $this->createMock(InjectionService::class);
         $service->expects($this->once())
             ->method('resolveConstructorInjection')
-            ->with($this->isInstanceOf(ContainerInterface::class), $this->equalTo(Service1::class))
+            ->with($this->isInstanceOf(ContainerInterface::class), Service1::class)
             ->willReturn([new Service2(), new Service3()]);
 
         $container = $this->createMock(ServiceLocatorInterface::class);
@@ -81,9 +81,9 @@ class InjectionFactoryTest extends TestCase
             ->method('getServiceLocator')
             ->willReturn($container);
 
-        $factory = new InjectionFactory();
+        $injectionFactory = new InjectionFactory();
 
-        $instance = $factory->createService($pluginManager, Service1::class);
+        $instance = $injectionFactory->createService($pluginManager, Service1::class);
 
         self::assertInstanceOf(Service1::class, $instance);
     }
@@ -93,7 +93,7 @@ class InjectionFactoryTest extends TestCase
         $service = $this->createMock(InjectionService::class);
         $service->expects($this->once())
             ->method('resolveConstructorInjection')
-            ->with($this->isInstanceOf(ContainerInterface::class), $this->equalTo(Service2::class))
+            ->with($this->isInstanceOf(ContainerInterface::class), Service2::class)
             ->willReturn(false);
 
         $container = $this->createMock(ServiceLocatorInterface::class);
@@ -102,9 +102,9 @@ class InjectionFactoryTest extends TestCase
             ->with(InjectionService::class)
             ->willReturn($service);
 
-        $factory = new InjectionFactory();
+        $injectionFactory = new InjectionFactory();
 
-        $instance = $factory->createService($container, Service2::class);
+        $instance = $injectionFactory->createService($container, Service2::class);
 
         self::assertInstanceOf(Service2::class, $instance);
     }
@@ -115,8 +115,8 @@ class InjectionFactoryTest extends TestCase
 
         $container = $this->createMock(ServiceLocatorInterface::class);
 
-        $factory = new InjectionFactory();
+        $injectionFactory = new InjectionFactory();
 
-        $factory->createService($container);
+        $injectionFactory->createService($container);
     }
 }

--- a/test/Unit/Injection/AutoWiringContainerTest.php
+++ b/test/Unit/Injection/AutoWiringContainerTest.php
@@ -11,14 +11,14 @@ use Reinfi\DependencyInjection\Injection\AutoWiringContainer;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Injection
  */
-class AutoWiringContainerTest extends TestCase
+final class AutoWiringContainerTest extends TestCase
 {
     public function testItReturnsContainer(): void
     {
         $container = $this->createMock(ContainerInterface::class);
 
-        $injection = new AutoWiringContainer();
+        $autoWiringContainer = new AutoWiringContainer();
 
-        self::assertInstanceOf(ContainerInterface::class, $injection($container));
+        self::assertInstanceOf(ContainerInterface::class, $autoWiringContainer($container));
     }
 }

--- a/test/Unit/Injection/AutoWiringPluginManagerTest.php
+++ b/test/Unit/Injection/AutoWiringPluginManagerTest.php
@@ -14,7 +14,7 @@ use Reinfi\DependencyInjection\Test\Service\Service1;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Injection
  */
-class AutoWiringPluginManagerTest extends TestCase
+final class AutoWiringPluginManagerTest extends TestCase
 {
     public function testItReturnsServiceFromContainer(): void
     {
@@ -33,9 +33,9 @@ class AutoWiringPluginManagerTest extends TestCase
             ->with('PluginManager')
             ->willReturn($pluginManager);
 
-        $injection = new AutoWiringPluginManager('PluginManager', Service1::class);
+        $autoWiringPluginManager = new AutoWiringPluginManager('PluginManager', Service1::class);
 
-        self::assertInstanceOf(Service1::class, $injection($container));
+        self::assertInstanceOf(Service1::class, $autoWiringPluginManager($container));
     }
 
     public function testItReturnsServiceFromParentLocator(): void
@@ -59,9 +59,9 @@ class AutoWiringPluginManagerTest extends TestCase
         $otherPluginManager->method('getServiceLocator')
             ->willReturn($container);
 
-        $injection = new AutoWiringPluginManager('PluginManager', Service1::class);
+        $autoWiringPluginManager = new AutoWiringPluginManager('PluginManager', Service1::class);
 
-        self::assertInstanceOf(Service1::class, $injection($otherPluginManager));
+        self::assertInstanceOf(Service1::class, $autoWiringPluginManager($otherPluginManager));
     }
 
     public function testItThrowsExceptionIfServiceNotFound(): void
@@ -78,8 +78,8 @@ class AutoWiringPluginManagerTest extends TestCase
             ->with('PluginManager')
             ->willReturn($pluginManager);
 
-        $injection = new AutoWiringPluginManager('PluginManager', Service1::class);
+        $autoWiringPluginManager = new AutoWiringPluginManager('PluginManager', Service1::class);
 
-        $injection($container);
+        $autoWiringPluginManager($container);
     }
 }

--- a/test/Unit/Injection/AutoWiringTest.php
+++ b/test/Unit/Injection/AutoWiringTest.php
@@ -14,7 +14,7 @@ use Reinfi\DependencyInjection\Test\Service\Service1;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Injection
  */
-class AutoWiringTest extends TestCase
+final class AutoWiringTest extends TestCase
 {
     public function testItReturnsServiceFromContainer(): void
     {
@@ -28,9 +28,9 @@ class AutoWiringTest extends TestCase
             ->with(Service1::class)
             ->willReturn($service1);
 
-        $injection = new AutoWiring(Service1::class);
+        $autoWiring = new AutoWiring(Service1::class);
 
-        self::assertInstanceOf(Service1::class, $injection($container));
+        self::assertInstanceOf(Service1::class, $autoWiring($container));
     }
 
     public function testItReturnsServiceFromParentLocator(): void
@@ -52,9 +52,9 @@ class AutoWiringTest extends TestCase
         $pluginManager->method('getServiceLocator')
             ->willReturn($container);
 
-        $injection = new AutoWiring(Service1::class);
+        $autoWiring = new AutoWiring(Service1::class);
 
-        self::assertInstanceOf(Service1::class, $injection($pluginManager));
+        self::assertInstanceOf(Service1::class, $autoWiring($pluginManager));
     }
 
     public function testItThrowsExceptionIfServiceNotFound(): void
@@ -66,8 +66,8 @@ class AutoWiringTest extends TestCase
             ->with(Service1::class)
             ->willReturn(false);
 
-        $injection = new AutoWiring(Service1::class);
+        $autoWiring = new AutoWiring(Service1::class);
 
-        $injection($container);
+        $autoWiring($container);
     }
 }

--- a/test/Unit/ModuleTest.php
+++ b/test/Unit/ModuleTest.php
@@ -10,7 +10,7 @@ use Reinfi\DependencyInjection\Module;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit
  */
-class ModuleTest extends TestCase
+final class ModuleTest extends TestCase
 {
     public function testItReturnsConfig(): void
     {

--- a/test/Unit/Service/AutoWiring/Factory/ResolverServiceFactoryTest.php
+++ b/test/Unit/Service/AutoWiring/Factory/ResolverServiceFactoryTest.php
@@ -20,17 +20,18 @@ use Reinfi\DependencyInjection\Test\Service\Resolver\TestResolver;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring\Factory
  */
-class ResolverServiceFactoryTest extends TestCase
+final class ResolverServiceFactoryTest extends TestCase
 {
     public function testItCreatesResolverServiceWithDefaultResolvers(): void
     {
         $container = $this->createMock(ContainerInterface::class);
 
         $container->method('get')
-            ->willReturnCallback(function ($service) {
+            ->willReturnCallback(function (string $service): mixed {
                 if ($service === ModuleConfig::class) {
                     return [];
                 }
+
                 return match ($service) {
                     ContainerResolver::class => $this->createMock(ContainerResolver::class),
                     PluginManagerResolver::class => $this->createMock(PluginManagerResolver::class),
@@ -42,11 +43,11 @@ class ResolverServiceFactoryTest extends TestCase
                 };
             });
 
-        $factory = new ResolverServiceFactory();
+        $resolverServiceFactory = new ResolverServiceFactory();
 
         self::assertInstanceOf(
             ResolverService::class,
-            $factory($container),
+            $resolverServiceFactory($container),
             'factory should return instance of ' . ResolverService::class
         );
     }
@@ -56,12 +57,13 @@ class ResolverServiceFactoryTest extends TestCase
         $container = $this->createMock(ContainerInterface::class);
 
         $container->method('get')
-            ->willReturnCallback(function ($service) {
+            ->willReturnCallback(function (string $service): mixed {
                 if ($service === ModuleConfig::class) {
                     return [
                         'autowire_resolver' => [TestResolver::class],
                     ];
                 }
+
                 return match ($service) {
                     ContainerResolver::class => $this->createMock(ContainerResolver::class),
                     PluginManagerResolver::class => $this->createMock(PluginManagerResolver::class),
@@ -74,11 +76,11 @@ class ResolverServiceFactoryTest extends TestCase
                 };
             });
 
-        $factory = new ResolverServiceFactory();
+        $resolverServiceFactory = new ResolverServiceFactory();
 
         self::assertInstanceOf(
             ResolverService::class,
-            $factory($container),
+            $resolverServiceFactory($container),
             'factory should return instance of ' . ResolverService::class
         );
     }

--- a/test/Unit/Service/AutoWiring/LazyResolverServiceTest.php
+++ b/test/Unit/Service/AutoWiring/LazyResolverServiceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring;
 
 use Interop\Container\ContainerInterface;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Reinfi\DependencyInjection\Service\AutoWiring\LazyResolverService;
 use Reinfi\DependencyInjection\Service\AutoWiring\ResolverService;
@@ -12,10 +13,9 @@ use Reinfi\DependencyInjection\Service\AutoWiring\ResolverServiceInterface;
 
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring
- *
- * @group unit
  */
-class LazyResolverServiceTest extends TestCase
+#[Group('unit')]
+final class LazyResolverServiceTest extends TestCase
 {
     public function testItResolvesResolverServiceLazy(): void
     {
@@ -31,9 +31,9 @@ class LazyResolverServiceTest extends TestCase
             ->with(ResolverService::class)
             ->willReturn($resolverService);
 
-        $service = new LazyResolverService($container);
+        $lazyResolverService = new LazyResolverService($container);
 
-        $service->resolve('test');
+        $lazyResolverService->resolve('test');
     }
 
     public function testItResolvesResolverServiceLazyWithOptions(): void
@@ -54,9 +54,9 @@ class LazyResolverServiceTest extends TestCase
             ->with(ResolverService::class)
             ->willReturn($resolverService);
 
-        $service = new LazyResolverService($container);
+        $lazyResolverService = new LazyResolverService($container);
 
-        $service->resolve('test', $options);
+        $lazyResolverService->resolve('test', $options);
     }
 
     public function testItResolvesResolverServiceOnlyOnce(): void
@@ -64,16 +64,17 @@ class LazyResolverServiceTest extends TestCase
         $resolverService = $this->createMock(ResolverServiceInterface::class);
         $resolverService->expects($this->exactly(2))
             ->method('resolve')
-            ->willReturnCallback(function (string $class, ?array $options) {
+            ->willReturnCallback(function (string $class, ?array $options): array {
                 static $calls = 0;
-                $calls++;
+                ++$calls;
                 if ($calls === 1) {
-                    $this->assertEquals('test', $class);
-                    $this->assertNull($options);
+                    self::assertSame('test', $class);
+                    self::assertNull($options);
                 } else {
-                    $this->assertEquals('test2', $class);
-                    $this->assertNull($options);
+                    self::assertSame('test2', $class);
+                    self::assertNull($options);
                 }
+
                 return [];
             });
 
@@ -83,9 +84,9 @@ class LazyResolverServiceTest extends TestCase
             ->with(ResolverService::class)
             ->willReturn($resolverService);
 
-        $service = new LazyResolverService($container);
+        $lazyResolverService = new LazyResolverService($container);
 
-        $service->resolve('test');
-        $service->resolve('test2');
+        $lazyResolverService->resolve('test');
+        $lazyResolverService->resolve('test2');
     }
 }

--- a/test/Unit/Service/AutoWiring/Resolver/BuildInTypeWithDefaultResolverTest.php
+++ b/test/Unit/Service/AutoWiring/Resolver/BuildInTypeWithDefaultResolverTest.php
@@ -13,11 +13,11 @@ use Reinfi\DependencyInjection\Service\AutoWiring\Resolver\BuildInTypeWithDefaul
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring\Resolver
  */
-class BuildInTypeWithDefaultResolverTest extends TestCase
+final class BuildInTypeWithDefaultResolverTest extends TestCase
 {
     public function testItReturnsInjectionInterface(): void
     {
-        $resolver = new BuildInTypeWithDefaultResolver();
+        $buildInTypeWithDefaultResolver = new BuildInTypeWithDefaultResolver();
 
         $type = $this->createMock(ReflectionNamedType::class);
         $type->method('isBuiltin')->willReturn(true);
@@ -29,26 +29,26 @@ class BuildInTypeWithDefaultResolverTest extends TestCase
             ->method('getDefaultValue')
             ->willReturn(0);
 
-        $injection = $resolver->resolve($parameter);
+        $injection = $buildInTypeWithDefaultResolver->resolve($parameter);
 
         self::assertInstanceOf(InjectionInterface::class, $injection);
     }
 
     public function testItReturnsNullIfNoType(): void
     {
-        $resolver = new BuildInTypeWithDefaultResolver();
+        $buildInTypeWithDefaultResolver = new BuildInTypeWithDefaultResolver();
 
         $parameter = $this->createMock(ReflectionParameter::class);
         $parameter->method('getType')->willReturn(null);
 
-        $injection = $resolver->resolve($parameter);
+        $injection = $buildInTypeWithDefaultResolver->resolve($parameter);
 
         self::assertNull($injection, 'Should be null if parameter has no type');
     }
 
     public function testItReturnsNullIfNoBuildInType(): void
     {
-        $resolver = new BuildInTypeWithDefaultResolver();
+        $buildInTypeWithDefaultResolver = new BuildInTypeWithDefaultResolver();
 
         $type = $this->createMock(ReflectionNamedType::class);
         $type->method('isBuiltin')->willReturn(false);
@@ -57,14 +57,14 @@ class BuildInTypeWithDefaultResolverTest extends TestCase
         $parameter->method('hasType')->willReturn(true);
         $parameter->method('getType')->willReturn($type);
 
-        $injection = $resolver->resolve($parameter);
+        $injection = $buildInTypeWithDefaultResolver->resolve($parameter);
 
         self::assertNull($injection, 'Should be null if parameter is not a buildin type');
     }
 
     public function testItReturnsNullIfNoDefaultValueAvailable(): void
     {
-        $resolver = new BuildInTypeWithDefaultResolver();
+        $buildInTypeWithDefaultResolver = new BuildInTypeWithDefaultResolver();
 
         $type = $this->createMock(ReflectionNamedType::class);
         $type->method('isBuiltin')->willReturn(true);
@@ -73,7 +73,7 @@ class BuildInTypeWithDefaultResolverTest extends TestCase
         $parameter->method('getType')->willReturn($type);
         $parameter->method('isDefaultValueAvailable')->willReturn(false);
 
-        $injection = $resolver->resolve($parameter);
+        $injection = $buildInTypeWithDefaultResolver->resolve($parameter);
 
         self::assertNull($injection, 'Should be null if parameter is not a buildin type');
     }

--- a/test/Unit/Service/AutoWiring/Resolver/ContainerInterfaceResolverTest.php
+++ b/test/Unit/Service/AutoWiring/Resolver/ContainerInterfaceResolverTest.php
@@ -17,85 +17,85 @@ use Reinfi\DependencyInjection\Test\Service\Service1;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring\Resolver
  */
-class ContainerInterfaceResolverTest extends TestCase
+final class ContainerInterfaceResolverTest extends TestCase
 {
     public function testItReturnsInjectionInterfaceIfIsInterfaceTypeHint(): void
     {
-        $resolver = new ContainerInterfaceResolver();
+        $containerInterfaceResolver = new ContainerInterfaceResolver();
 
         $type = $this->createMock(ReflectionNamedType::class);
         $type->method('getName')->willReturn(ContainerInterface::class);
         $parameter = $this->createMock(ReflectionParameter::class);
         $parameter->method('getType')->willReturn($type);
 
-        $injection = $resolver->resolve($parameter);
+        $injection = $containerInterfaceResolver->resolve($parameter);
 
         self::assertInstanceOf(InjectionInterface::class, $injection);
     }
 
     public function testItReturnsInjectionInterfaceIfHasInterfaceImplemented(): void
     {
-        $resolver = new ContainerInterfaceResolver();
+        $containerInterfaceResolver = new ContainerInterfaceResolver();
 
         $type = $this->createMock(ReflectionNamedType::class);
         $type->method('getName')->willReturn(ServiceLocatorInterface::class);
         $parameter = $this->createMock(ReflectionParameter::class);
         $parameter->method('getType')->willReturn($type);
 
-        $injection = $resolver->resolve($parameter);
+        $injection = $containerInterfaceResolver->resolve($parameter);
 
         self::assertInstanceOf(InjectionInterface::class, $injection);
     }
 
     public function testItReturnsNullIfIsAbstractPluginManager(): void
     {
-        $resolver = new ContainerInterfaceResolver();
+        $containerInterfaceResolver = new ContainerInterfaceResolver();
         $type = $this->createMock(ReflectionNamedType::class);
         $type->method('getName')->willReturn(AbstractPluginManager::class);
         $parameter = $this->createMock(ReflectionParameter::class);
         $parameter->method('getType')->willReturn($type);
 
-        $injection = $resolver->resolve($parameter);
+        $injection = $containerInterfaceResolver->resolve($parameter);
 
         self::assertNull($injection);
     }
 
     public function testItReturnsNullIfOtherClass(): void
     {
-        $resolver = new ContainerInterfaceResolver();
+        $containerInterfaceResolver = new ContainerInterfaceResolver();
 
         $type = $this->createMock(ReflectionNamedType::class);
         $type->method('getName')->willReturn(Service1::class);
         $parameter = $this->createMock(ReflectionParameter::class);
         $parameter->method('getType')->willReturn($type);
 
-        $injection = $resolver->resolve($parameter);
+        $injection = $containerInterfaceResolver->resolve($parameter);
 
         self::assertNull($injection);
     }
 
     public function testItReturnsNullIfClassDoesNotExists(): void
     {
-        $resolver = new ContainerInterfaceResolver();
+        $containerInterfaceResolver = new ContainerInterfaceResolver();
 
         $type = $this->createMock(ReflectionNamedType::class);
         $type->method('getName')->willReturn('ServiceWhichDoesNotExists');
         $parameter = $this->createMock(ReflectionParameter::class);
         $parameter->method('getType')->willReturn($type);
 
-        $injection = $resolver->resolve($parameter);
+        $injection = $containerInterfaceResolver->resolve($parameter);
 
         self::assertNull($injection);
     }
 
     public function testItReturnsNullIfParameterHasNoType(): void
     {
-        $resolver = new ContainerInterfaceResolver();
+        $containerInterfaceResolver = new ContainerInterfaceResolver();
 
         $parameter = $this->createMock(ReflectionParameter::class);
         $parameter->method('getType')->willReturn(null);
 
-        $injection = $resolver->resolve($parameter);
+        $injection = $containerInterfaceResolver->resolve($parameter);
 
         self::assertNull($injection);
     }

--- a/test/Unit/Service/AutoWiring/Resolver/ContainerResolverTest.php
+++ b/test/Unit/Service/AutoWiring/Resolver/ContainerResolverTest.php
@@ -16,7 +16,7 @@ use Reinfi\DependencyInjection\Test\Service\Service1;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring\Resolver
  */
-class ContainerResolverTest extends TestCase
+final class ContainerResolverTest extends TestCase
 {
     public function testItReturnsInjectionInterface(): void
     {
@@ -26,14 +26,14 @@ class ContainerResolverTest extends TestCase
             ->with(Service1::class)
             ->willReturn(true);
 
-        $resolver = new ContainerResolver($container);
+        $containerResolver = new ContainerResolver($container);
 
         $type = $this->createMock(ReflectionNamedType::class);
         $type->method('getName')->willReturn(Service1::class);
         $parameter = $this->createMock(ReflectionParameter::class);
         $parameter->method('getType')->willReturn($type);
 
-        $injection = $resolver->resolve($parameter);
+        $injection = $containerResolver->resolve($parameter);
 
         self::assertInstanceOf(InjectionInterface::class, $injection);
     }
@@ -46,20 +46,20 @@ class ContainerResolverTest extends TestCase
             ->with(Service1::class)
             ->willReturn(true);
 
-        $resolver = new ContainerResolver($container);
+        $containerResolver = new ContainerResolver($container);
 
         $type = $this->createMock(ReflectionNamedType::class);
         $type->method('getName')->willReturn(Service1::class);
         $parameter = $this->createMock(ReflectionParameter::class);
         $parameter->method('getType')->willReturn($type);
 
-        $injection = $resolver->resolve($parameter);
+        $injection = $containerResolver->resolve($parameter);
 
-        $reflCass = new ReflectionClass($injection);
-        $property = $reflCass->getProperty('serviceName');
-        $property->setAccessible(true);
+        $reflectionClass = new ReflectionClass($injection);
+        $reflectionProperty = $reflectionClass->getProperty('serviceName');
+        $reflectionProperty->setAccessible(true);
 
-        self::assertEquals(Service1::class, $property->getValue($injection));
+        self::assertEquals(Service1::class, $reflectionProperty->getValue($injection));
     }
 
     public function testItReturnsNullIfServiceNotFound(): void
@@ -70,14 +70,14 @@ class ContainerResolverTest extends TestCase
             ->with(Service1::class)
             ->willReturn(false);
 
-        $resolver = new ContainerResolver($container);
+        $containerResolver = new ContainerResolver($container);
 
         $type = $this->createMock(ReflectionNamedType::class);
         $type->method('getName')->willReturn(Service1::class);
         $parameter = $this->createMock(ReflectionParameter::class);
         $parameter->method('getType')->willReturn($type);
 
-        $injection = $resolver->resolve($parameter);
+        $injection = $containerResolver->resolve($parameter);
 
         self::assertNull($injection);
     }
@@ -86,12 +86,12 @@ class ContainerResolverTest extends TestCase
     {
         $container = $this->createMock(ContainerInterface::class);
 
-        $resolver = new ContainerResolver($container);
+        $containerResolver = new ContainerResolver($container);
 
         $parameter = $this->createMock(ReflectionParameter::class);
         $parameter->method('getType')->willReturn(null);
 
-        $injection = $resolver->resolve($parameter);
+        $injection = $containerResolver->resolve($parameter);
 
         self::assertNull($injection);
     }

--- a/test/Unit/Service/AutoWiring/Resolver/Factory/ContainerResolverFactoryTest.php
+++ b/test/Unit/Service/AutoWiring/Resolver/Factory/ContainerResolverFactoryTest.php
@@ -12,14 +12,14 @@ use Reinfi\DependencyInjection\Service\AutoWiring\Resolver\Factory\ContainerReso
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring\Resolver\Factory
  */
-class ContainerResolverFactoryTest extends TestCase
+final class ContainerResolverFactoryTest extends TestCase
 {
     public function testItReturnsContainerResolver(): void
     {
         $container = $this->createMock(ContainerInterface::class);
 
-        $factory = new ContainerResolverFactory();
+        $containerResolverFactory = new ContainerResolverFactory();
 
-        self::assertInstanceOf(ContainerResolver::class, $factory($container));
+        self::assertInstanceOf(ContainerResolver::class, $containerResolverFactory($container));
     }
 }

--- a/test/Unit/Service/AutoWiring/Resolver/Factory/PluginManagerResolverFactoryTest.php
+++ b/test/Unit/Service/AutoWiring/Resolver/Factory/PluginManagerResolverFactoryTest.php
@@ -12,14 +12,14 @@ use Reinfi\DependencyInjection\Service\AutoWiring\Resolver\PluginManagerResolver
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring\Resolver\Factory
  */
-class PluginManagerResolverFactoryTest extends TestCase
+final class PluginManagerResolverFactoryTest extends TestCase
 {
     public function testItReturnsPluginManagerResolver(): void
     {
         $container = $this->createMock(ContainerInterface::class);
 
-        $factory = new PluginManagerResolverFactory();
+        $pluginManagerResolverFactory = new PluginManagerResolverFactory();
 
-        self::assertInstanceOf(PluginManagerResolver::class, $factory($container));
+        self::assertInstanceOf(PluginManagerResolver::class, $pluginManagerResolverFactory($container));
     }
 }

--- a/test/Unit/Service/AutoWiring/Resolver/Factory/TranslatorResolverFactoryTest.php
+++ b/test/Unit/Service/AutoWiring/Resolver/Factory/TranslatorResolverFactoryTest.php
@@ -12,14 +12,14 @@ use Reinfi\DependencyInjection\Service\AutoWiring\Resolver\TranslatorResolver;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring\Resolver\Factory
  */
-class TranslatorResolverFactoryTest extends TestCase
+final class TranslatorResolverFactoryTest extends TestCase
 {
     public function testItReturnsTranslatorResolver(): void
     {
         $container = $this->createMock(ContainerInterface::class);
 
-        $factory = new TranslatorResolverFactory();
+        $translatorResolverFactory = new TranslatorResolverFactory();
 
-        self::assertInstanceOf(TranslatorResolver::class, $factory($container));
+        self::assertInstanceOf(TranslatorResolver::class, $translatorResolverFactory($container));
     }
 }

--- a/test/Unit/Service/AutoWiring/Resolver/PluginManagerResolverTest.php
+++ b/test/Unit/Service/AutoWiring/Resolver/PluginManagerResolverTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring\Resolver;
 
+use Iterator;
 use Laminas\Filter\ToInt;
 use Laminas\Form\Element\Textarea;
 use Laminas\Hydrator\ReflectionHydrator;
@@ -25,7 +26,7 @@ use Reinfi\DependencyInjection\Test\Service\ServiceWithInterface;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring\Resolver
  */
-class PluginManagerResolverTest extends TestCase
+final class PluginManagerResolverTest extends TestCase
 {
     #[DataProvider('getPluginManagerData')]
     public function testItReturnsInjectionInterfaceForPluginManager(
@@ -42,7 +43,7 @@ class PluginManagerResolverTest extends TestCase
             ->with($pluginManager)
             ->willReturn($pluginManagerClass);
 
-        $resolver = new PluginManagerResolver($container);
+        $pluginManagerResolver = new PluginManagerResolver($container);
 
         $type = $this->createMock(ReflectionNamedType::class);
         $type->method('getName')
@@ -51,7 +52,7 @@ class PluginManagerResolverTest extends TestCase
         $parameter->method('getType')
             ->willReturn($type);
 
-        $injection = $resolver->resolve($parameter);
+        $injection = $pluginManagerResolver->resolve($parameter);
 
         self::assertInstanceOf(AutoWiringPluginManager::class, $injection);
     }
@@ -69,7 +70,7 @@ class PluginManagerResolverTest extends TestCase
             ->with($pluginManager)
             ->willReturn($pluginManagerClass);
 
-        $resolver = new PluginManagerResolver($container);
+        $pluginManagerResolver = new PluginManagerResolver($container);
 
         $type = $this->createMock(ReflectionNamedType::class);
         $type->method('getName')
@@ -78,7 +79,7 @@ class PluginManagerResolverTest extends TestCase
         $parameter->method('getType')
             ->willReturn($type);
 
-        $injection = $resolver->resolve($parameter);
+        $injection = $pluginManagerResolver->resolve($parameter);
 
         self::assertNotNull($injection, 'injection could not resolved');
 
@@ -107,7 +108,7 @@ class PluginManagerResolverTest extends TestCase
         $container->method('get')
             ->with('InjectionManager')
             ->willReturn($pluginManagerClass);
-        $resolver = new PluginManagerResolver($container);
+        $pluginManagerResolver = new PluginManagerResolver($container);
 
         $type = $this->createMock(ReflectionNamedType::class);
         $type->method('getName')
@@ -116,21 +117,21 @@ class PluginManagerResolverTest extends TestCase
         $parameter->method('getType')
             ->willReturn($type);
 
-        $injection = $resolver->resolve($parameter);
+        $injection = $pluginManagerResolver->resolve($parameter);
 
         self::assertNotNull($injection, 'injection could not resolved');
 
-        $reflCass = new ReflectionClass($injection);
-        $property = $reflCass->getProperty('pluginManager');
-        $property->setAccessible(true);
+        $reflectionClass = new ReflectionClass($injection);
+        $reflectionProperty = $reflectionClass->getProperty('pluginManager');
+        $reflectionProperty->setAccessible(true);
 
-        self::assertEquals('InjectionManager', $property->getValue($injection));
+        self::assertEquals('InjectionManager', $reflectionProperty->getValue($injection));
     }
 
     public function testItReturnsNullIfNoPluginManagerFound(): void
     {
         $container = $this->createMock(ContainerInterface::class);
-        $resolver = new PluginManagerResolver($container);
+        $pluginManagerResolver = new PluginManagerResolver($container);
 
         $type = $this->createMock(ReflectionNamedType::class);
         $type->method('getName')
@@ -139,33 +140,31 @@ class PluginManagerResolverTest extends TestCase
         $parameter->method('getType')
             ->willReturn($type);
 
-        self::assertNull($resolver->resolve($parameter), 'return value should be null if not found');
+        self::assertNull($pluginManagerResolver->resolve($parameter), 'return value should be null if not found');
     }
 
     public function testItReturnsNullIfParameterHasNoType(): void
     {
         $container = $this->createMock(ContainerInterface::class);
 
-        $resolver = new PluginManagerResolver($container);
+        $pluginManagerResolver = new PluginManagerResolver($container);
 
         $parameter = $this->createMock(ReflectionParameter::class);
         $parameter->method('getType')
             ->willReturn(null);
 
-        $injection = $resolver->resolve($parameter);
+        $injection = $pluginManagerResolver->resolve($parameter);
 
         self::assertNull($injection);
     }
 
-    public static function getPluginManagerData(): array
+    public static function getPluginManagerData(): Iterator
     {
-        return [
-            [ReflectionHydrator::class, 'HydratorManager'],
-            [Url::class, 'ViewHelperManager'],
-            [Digits::class, 'ValidatorManager'],
-            [ToInt::class, 'FilterManager'],
-            [InputFilter::class, 'InputFilterManager'],
-            [Textarea::class, 'FormElementManager'],
-        ];
+        yield [ReflectionHydrator::class, 'HydratorManager'];
+        yield [Url::class, 'ViewHelperManager'];
+        yield [Digits::class, 'ValidatorManager'];
+        yield [ToInt::class, 'FilterManager'];
+        yield [InputFilter::class, 'InputFilterManager'];
+        yield [Textarea::class, 'FormElementManager'];
     }
 }

--- a/test/Unit/Service/AutoWiring/Resolver/RequestResolverTest.php
+++ b/test/Unit/Service/AutoWiring/Resolver/RequestResolverTest.php
@@ -16,67 +16,67 @@ use Reinfi\DependencyInjection\Test\Service\Service1;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring\Resolver
  */
-class RequestResolverTest extends TestCase
+final class RequestResolverTest extends TestCase
 {
     public function testItReturnsInjectionInterfaceForRequestInterface(): void
     {
-        $resolver = new RequestResolver();
+        $requestResolver = new RequestResolver();
 
         $type = $this->createMock(ReflectionNamedType::class);
         $type->method('getName')->willReturn(RequestInterface::class);
         $parameter = $this->createMock(ReflectionParameter::class);
         $parameter->method('getType')->willReturn($type);
 
-        $injection = $resolver->resolve($parameter);
+        $injection = $requestResolver->resolve($parameter);
 
         self::assertInstanceOf(AutoWiring::class, $injection);
     }
 
     public function testItReturnsInjectionInterfaceForRequestClass(): void
     {
-        $resolver = new RequestResolver();
+        $requestResolver = new RequestResolver();
 
         $type = $this->createMock(ReflectionNamedType::class);
         $type->method('getName')->willReturn(Request::class);
         $parameter = $this->createMock(ReflectionParameter::class);
         $parameter->method('getType')->willReturn($type);
 
-        $injection = $resolver->resolve($parameter);
+        $injection = $requestResolver->resolve($parameter);
 
         self::assertInstanceOf(AutoWiring::class, $injection);
     }
 
     public function testItReturnsNullIfNoRequest(): void
     {
-        $resolver = new RequestResolver();
+        $requestResolver = new RequestResolver();
 
         $type = $this->createMock(ReflectionNamedType::class);
         $type->method('getName')->willReturn(Service1::class);
         $parameter = $this->createMock(ReflectionParameter::class);
         $parameter->method('getType')->willReturn($type);
 
-        self::assertNull($resolver->resolve($parameter), 'return value should be null if not found');
+        self::assertNull($requestResolver->resolve($parameter), 'return value should be null if not found');
     }
 
     public function testItReturnsNullIfClassDoesNotExists(): void
     {
-        $resolver = new RequestResolver();
+        $requestResolver = new RequestResolver();
 
         $type = $this->createMock(ReflectionNamedType::class);
         $type->method('getName')->willReturn('ServiceWhichDoesNotExists');
         $parameter = $this->createMock(ReflectionParameter::class);
         $parameter->method('getType')->willReturn($type);
 
-        self::assertNull($resolver->resolve($parameter), 'return value should be null if not found');
+        self::assertNull($requestResolver->resolve($parameter), 'return value should be null if not found');
     }
 
     public function testItReturnsNullIfParameterHasNoClass(): void
     {
-        $resolver = new RequestResolver();
+        $requestResolver = new RequestResolver();
 
         $parameter = $this->createMock(ReflectionParameter::class);
         $parameter->method('getType')->willReturn(null);
 
-        self::assertNull($resolver->resolve($parameter), 'return value should be null if not found');
+        self::assertNull($requestResolver->resolve($parameter), 'return value should be null if not found');
     }
 }

--- a/test/Unit/Service/AutoWiring/Resolver/ResponseResolverTest.php
+++ b/test/Unit/Service/AutoWiring/Resolver/ResponseResolverTest.php
@@ -16,11 +16,11 @@ use Reinfi\DependencyInjection\Test\Service\Service1;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring\Resolver
  */
-class ResponseResolverTest extends TestCase
+final class ResponseResolverTest extends TestCase
 {
     public function testItReturnsInjectionInterfaceForResponseInterface(): void
     {
-        $resolver = new ResponseResolver();
+        $responseResolver = new ResponseResolver();
 
         $type = $this->createMock(ReflectionNamedType::class);
         $type->method('getName')->willReturn(ResponseInterface::class);
@@ -28,14 +28,14 @@ class ResponseResolverTest extends TestCase
         $parameter = $this->createMock(ReflectionParameter::class);
         $parameter->method('getType')->willReturn($type);
 
-        $injection = $resolver->resolve($parameter);
+        $injection = $responseResolver->resolve($parameter);
 
         self::assertInstanceOf(AutoWiring::class, $injection);
     }
 
     public function testItReturnsInjectionInterfaceForResponseClass(): void
     {
-        $resolver = new ResponseResolver();
+        $responseResolver = new ResponseResolver();
 
         $type = $this->createMock(ReflectionNamedType::class);
         $type->method('getName')->willReturn(Response::class);
@@ -43,14 +43,14 @@ class ResponseResolverTest extends TestCase
         $parameter = $this->createMock(ReflectionParameter::class);
         $parameter->method('getType')->willReturn($type);
 
-        $injection = $resolver->resolve($parameter);
+        $injection = $responseResolver->resolve($parameter);
 
         self::assertInstanceOf(AutoWiring::class, $injection);
     }
 
     public function testItReturnsNullIfNoResponse(): void
     {
-        $resolver = new ResponseResolver();
+        $responseResolver = new ResponseResolver();
 
         $type = $this->createMock(ReflectionNamedType::class);
         $type->method('getName')->willReturn(Service1::class);
@@ -58,12 +58,12 @@ class ResponseResolverTest extends TestCase
         $parameter = $this->createMock(ReflectionParameter::class);
         $parameter->method('getType')->willReturn($type);
 
-        self::assertNull($resolver->resolve($parameter), 'return value should be null if not found');
+        self::assertNull($responseResolver->resolve($parameter), 'return value should be null if not found');
     }
 
     public function testItReturnsNullIfClassDoesNotExists(): void
     {
-        $resolver = new ResponseResolver();
+        $responseResolver = new ResponseResolver();
 
         $type = $this->createMock(ReflectionNamedType::class);
         $type->method('getName')->willReturn('ServiceWhichDoesNotExists');
@@ -71,16 +71,16 @@ class ResponseResolverTest extends TestCase
         $parameter = $this->createMock(ReflectionParameter::class);
         $parameter->method('getType')->willReturn($type);
 
-        self::assertNull($resolver->resolve($parameter), 'return value should be null if not found');
+        self::assertNull($responseResolver->resolve($parameter), 'return value should be null if not found');
     }
 
     public function testItReturnsNullIfParameterHasNoClass(): void
     {
-        $resolver = new ResponseResolver();
+        $responseResolver = new ResponseResolver();
 
         $parameter = $this->createMock(ReflectionParameter::class);
         $parameter->method('getType')->willReturn(null);
 
-        self::assertNull($resolver->resolve($parameter), 'return value should be null if not found');
+        self::assertNull($responseResolver->resolve($parameter), 'return value should be null if not found');
     }
 }

--- a/test/Unit/Service/AutoWiring/ResolverServiceTest.php
+++ b/test/Unit/Service/AutoWiring/ResolverServiceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring;
 
 use Interop\Container\ContainerInterface;
+use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionParameter;
@@ -21,7 +22,7 @@ use Reinfi\DependencyInjection\Test\Service\ServiceNoTypeHint;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Service\AutoWiring
  */
-class ResolverServiceTest extends TestCase
+final class ResolverServiceTest extends TestCase
 {
     public function testItResolvesConstructorArguments(): void
     {
@@ -30,9 +31,9 @@ class ResolverServiceTest extends TestCase
             ->with($this->isInstanceOf(ReflectionParameter::class))
             ->willReturn(new AutoWiring(Service2::class));
 
-        $service = new ResolverService([$resolver]);
+        $resolverService = new ResolverService([$resolver]);
 
-        $injections = $service->resolve(Service1::class);
+        $injections = $resolverService->resolve(Service1::class);
 
         self::assertCount(3, $injections);
         self::assertContainsOnlyInstancesOf(InjectionInterface::class, $injections);
@@ -45,10 +46,10 @@ class ResolverServiceTest extends TestCase
             ->with($this->isInstanceOf(ReflectionParameter::class))
             ->willReturn(new AutoWiring(Service2::class));
 
-        $service = new ResolverService([$resolver]);
+        $resolverService = new ResolverService([$resolver]);
 
         $container = $this->createMock(ContainerInterface::class);
-        $injections = $service->resolve(Service1::class, [
+        $injections = $resolverService->resolve(Service1::class, [
             'foo' => 'bar',
         ]);
 
@@ -61,9 +62,9 @@ class ResolverServiceTest extends TestCase
     {
         $resolver = $this->createMock(ResolverInterface::class);
 
-        $service = new ResolverService([$resolver]);
+        $resolverService = new ResolverService([$resolver]);
 
-        $injections = $service->resolve(Service2::class);
+        $injections = $resolverService->resolve(Service2::class);
 
         self::assertCount(0, $injections);
     }
@@ -78,9 +79,9 @@ class ResolverServiceTest extends TestCase
             ->with($this->isInstanceOf(ReflectionParameter::class))
             ->willReturn(null);
 
-        $service = new ResolverService([$resolver]);
+        $resolverService = new ResolverService([$resolver]);
 
-        $service->resolve($serviceClass);
+        $resolverService->resolve($serviceClass);
     }
 
     #[DataProvider('exceptionServiceDataProvider')]
@@ -93,13 +94,15 @@ class ResolverServiceTest extends TestCase
             ->with($this->isInstanceOf(ReflectionParameter::class))
             ->willReturn(null);
 
-        $service = new ResolverService([$resolver]);
+        $resolverService = new ResolverService([$resolver]);
 
-        $service->resolve($serviceClass);
+        $resolverService->resolve($serviceClass);
     }
 
-    public static function exceptionServiceDataProvider(): array
+    public static function exceptionServiceDataProvider(): Iterator
     {
-        return [[Service1::class], [ServiceNoTypeHint::class], [ServiceBuildInType::class]];
+        yield [Service1::class];
+        yield [ServiceNoTypeHint::class];
+        yield [ServiceBuildInType::class];
     }
 }

--- a/test/Unit/Service/AutoWiringServiceTest.php
+++ b/test/Unit/Service/AutoWiringServiceTest.php
@@ -17,7 +17,7 @@ use Reinfi\DependencyInjection\Traits\CacheKeyTrait;
 /**
  * @package Reinfi\DependencyInjection\Test\Test\Unit\Service
  */
-class AutoWiringServiceTest extends TestCase
+final class AutoWiringServiceTest extends TestCase
 {
     use CacheKeyTrait;
 
@@ -55,12 +55,12 @@ class AutoWiringServiceTest extends TestCase
         $cache->expects($this->never())->method('has');
         $cache->expects($this->never())->method('set');
 
-        $service = new AutoWiringService($resolver, $cache);
+        $autoWiringService = new AutoWiringService($resolver, $cache);
 
         // Create container mock
         $container = $this->createMock(ContainerInterface::class);
 
-        $injections = $service->resolveConstructorInjection($container, Service1::class, $options);
+        $injections = $autoWiringService->resolveConstructorInjection($container, Service1::class, $options);
 
         self::assertCount(2, $injections);
     }
@@ -97,12 +97,12 @@ class AutoWiringServiceTest extends TestCase
             ->with($cacheKey, $this->isArray())
             ->willReturn(true);
 
-        $service = new AutoWiringService($resolver, $cache);
+        $autoWiringService = new AutoWiringService($resolver, $cache);
 
         // Create container mock
         $container = $this->createMock(ContainerInterface::class);
 
-        $injections = $service->resolveConstructorInjection($container, Service1::class);
+        $injections = $autoWiringService->resolveConstructorInjection($container, Service1::class);
 
         self::assertCount(1, $injections);
     }
@@ -133,12 +133,12 @@ class AutoWiringServiceTest extends TestCase
             ->with($cacheKey)
             ->willReturn([$injection]);
 
-        $service = new AutoWiringService($resolver, $cache);
+        $autoWiringService = new AutoWiringService($resolver, $cache);
 
         // Create container mock
         $container = $this->createMock(ContainerInterface::class);
 
-        $injections = $service->resolveConstructorInjection($container, Service1::class);
+        $injections = $autoWiringService->resolveConstructorInjection($container, Service1::class);
 
         self::assertCount(1, $injections);
     }
@@ -178,12 +178,12 @@ class AutoWiringServiceTest extends TestCase
         $cache->expects($this->never())->method('has');
         $cache->expects($this->never())->method('get');
 
-        $service = new AutoWiringService($resolver, $cache);
+        $autoWiringService = new AutoWiringService($resolver, $cache);
 
         // Create container mock
         $container = $this->createMock(ContainerInterface::class);
 
-        $injections = $service->resolveConstructorInjection($container, Service1::class, $options);
+        $injections = $autoWiringService->resolveConstructorInjection($container, Service1::class, $options);
 
         self::assertCount(2, $injections);
     }
@@ -225,12 +225,12 @@ class AutoWiringServiceTest extends TestCase
             ->with($cacheKey, $this->isArray())
             ->willReturn(true);
 
-        $service = new AutoWiringService($resolver, $cache);
+        $autoWiringService = new AutoWiringService($resolver, $cache);
 
         // Create container mock
         $container = $this->createMock(ContainerInterface::class);
 
-        $injections = $service->resolveConstructorInjection($container, Service1::class);
+        $injections = $autoWiringService->resolveConstructorInjection($container, Service1::class);
 
         self::assertCount(1, $injections);
     }
@@ -258,12 +258,12 @@ class AutoWiringServiceTest extends TestCase
             ->with($cacheKey, $this->isArray())
             ->willReturn(true);
 
-        $service = new AutoWiringService($resolver, $cache);
+        $autoWiringService = new AutoWiringService($resolver, $cache);
 
         // Create container mock
         $container = $this->createMock(ContainerInterface::class);
 
-        $injections = $service->resolveConstructorInjection($container, Service2::class);
+        $injections = $autoWiringService->resolveConstructorInjection($container, Service2::class);
 
         self::assertNull($injections, 'Return value should be null if service has no injections');
     }

--- a/test/Unit/Service/Cache/MemoryTest.php
+++ b/test/Unit/Service/Cache/MemoryTest.php
@@ -9,55 +9,55 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Reinfi\DependencyInjection\Service\Cache\Memory;
 
-class MemoryTest extends TestCase
+final class MemoryTest extends TestCase
 {
     public function testItStoresCachedContents(): void
     {
-        $cache = new Memory();
+        $memory = new Memory();
 
-        self::assertTrue($cache->set('test', 'cachedValue'), 'Cache set should return true');
+        self::assertTrue($memory->set('test', 'cachedValue'), 'Cache set should return true');
 
-        self::assertTrue($cache->has('test'), 'Cache has should return true');
+        self::assertTrue($memory->has('test'), 'Cache has should return true');
 
-        self::assertEquals('cachedValue', $cache->get('test'), 'Cache get should return stored value');
+        self::assertEquals('cachedValue', $memory->get('test'), 'Cache get should return stored value');
     }
 
     public function testItHandlesNotStoredContents(): void
     {
-        $cache = new Memory();
+        $memory = new Memory();
 
-        self::assertFalse($cache->has('test'), 'Cache has should return false if not stored');
+        self::assertFalse($memory->has('test'), 'Cache has should return false if not stored');
 
-        self::assertNull($cache->get('test'), 'Cache get should return default value for not stored value');
+        self::assertNull($memory->get('test'), 'Cache get should return default value for not stored value');
     }
 
     public function testItDeletesStoredContents(): void
     {
-        $cache = new Memory();
+        $memory = new Memory();
 
-        $cache->set('test', 'cachedValue');
+        $memory->set('test', 'cachedValue');
 
-        self::assertTrue($cache->has('test'), 'Cache has should return true');
+        self::assertTrue($memory->has('test'), 'Cache has should return true');
 
-        self::assertTrue($cache->delete('test'), 'Cache get should return stored value');
+        self::assertTrue($memory->delete('test'), 'Cache get should return stored value');
 
-        self::assertFalse($cache->has('test'), 'Cache has should return false for deleted item');
+        self::assertFalse($memory->has('test'), 'Cache has should return false for deleted item');
     }
 
     public function testItClearsStoredContents(): void
     {
-        $cache = new Memory();
+        $memory = new Memory();
 
-        $cache->set('test', 'cachedValue');
-        $cache->set('test2', 'cachedValue');
+        $memory->set('test', 'cachedValue');
+        $memory->set('test2', 'cachedValue');
 
-        self::assertTrue($cache->has('test'), 'Cache has should return true');
+        self::assertTrue($memory->has('test'), 'Cache has should return true');
 
-        self::assertTrue($cache->clear(), 'Cache get should return stored value');
+        self::assertTrue($memory->clear(), 'Cache get should return stored value');
 
-        self::assertFalse($cache->has('test'), 'Cache has should return false for cleared items');
+        self::assertFalse($memory->has('test'), 'Cache has should return false for cleared items');
 
-        self::assertFalse($cache->has('test2'), 'Cache has should return false for cleared items');
+        self::assertFalse($memory->has('test2'), 'Cache has should return false for cleared items');
     }
 
     #[DataProvider('badMethodDataProvider')]
@@ -65,9 +65,9 @@ class MemoryTest extends TestCase
     {
         $this->expectException(BadMethodCallException::class);
 
-        $cache = new Memory();
+        $memory = new Memory();
 
-        call_user_func([$cache, $methodName], $methodParams);
+        call_user_func([$memory, $methodName], $methodParams);
     }
 
     public static function badMethodDataProvider(): array

--- a/test/Unit/Service/CacheServiceTest.php
+++ b/test/Unit/Service/CacheServiceTest.php
@@ -13,7 +13,7 @@ use stdClass;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Service
  */
-class CacheServiceTest extends TestCase
+final class CacheServiceTest extends TestCase
 {
     #[DataProvider('getMethodDataProvider')]
     public function testItProxiesCallToUnderlyingCache(
@@ -29,11 +29,11 @@ class CacheServiceTest extends TestCase
             ->with(...$arguments)
             ->willReturn($returnValue);
 
-        $service = new CacheService($cache);
+        $cacheService = new CacheService($cache);
 
-        $result = call_user_func_array([$service, $method], $params);
+        $result = call_user_func_array([$cacheService, $method], $params);
 
-        $this->assertSame($expectedResult, $result);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function getMethodDataProvider(): array
@@ -56,6 +56,6 @@ class CacheServiceTest extends TestCase
 
         $cacheService = new CacheService($cache);
 
-        $this->assertNull($cacheService->get('key'));
+        self::assertNull($cacheService->get('key'));
     }
 }

--- a/test/Unit/Service/ConfigServiceTest.php
+++ b/test/Unit/Service/ConfigServiceTest.php
@@ -11,7 +11,7 @@ use Reinfi\DependencyInjection\Service\ConfigService;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Service
  */
-class ConfigServiceTest extends TestCase
+final class ConfigServiceTest extends TestCase
 {
     public function testItResolvesConfigPath(): void
     {
@@ -43,8 +43,8 @@ class ConfigServiceTest extends TestCase
             'test' => [],
         ];
 
-        $service = new ConfigService($config);
+        $configService = new ConfigService($config);
 
-        $service->resolve('test.valueMustExist!');
+        $configService->resolve('test.valueMustExist!');
     }
 }

--- a/test/Unit/Service/Extractor/AnnotationExtractorTest.php
+++ b/test/Unit/Service/Extractor/AnnotationExtractorTest.php
@@ -15,7 +15,7 @@ use Reinfi\DependencyInjection\Test\Service\ServiceAnnotation;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Service\Extractor
  */
-class AnnotationExtractorTest extends TestCase
+final class AnnotationExtractorTest extends TestCase
 {
     public function testItResolvesPropertyAnnotations(): void
     {
@@ -24,12 +24,12 @@ class AnnotationExtractorTest extends TestCase
         $reader = $this->createMock(AnnotationReader::class);
         $reader->expects($this->exactly(3))
             ->method('getPropertyAnnotation')
-            ->with($this->isInstanceOf(ReflectionProperty::class), $this->equalTo(AnnotationInterface::class))
+            ->with($this->isInstanceOf(ReflectionProperty::class), AnnotationInterface::class)
             ->willReturn($annotation);
 
-        $extractor = new AnnotationExtractor($reader);
+        $annotationExtractor = new AnnotationExtractor($reader);
 
-        $injections = $extractor->getPropertiesInjections(ServiceAnnotation::class);
+        $injections = $annotationExtractor->getPropertiesInjections(ServiceAnnotation::class);
 
         self::assertCount(3, $injections);
         self::assertContainsOnlyInstancesOf(AnnotationInterface::class, $injections);
@@ -45,9 +45,9 @@ class AnnotationExtractorTest extends TestCase
             ->with($this->isInstanceOf(ReflectionMethod::class))
             ->willReturn([$annotation, $annotation]);
 
-        $extractor = new AnnotationExtractor($reader);
+        $annotationExtractor = new AnnotationExtractor($reader);
 
-        $injections = $extractor->getConstructorInjections(ServiceAnnotation::class);
+        $injections = $annotationExtractor->getConstructorInjections(ServiceAnnotation::class);
 
         self::assertCount(2, $injections);
         self::assertContainsOnlyInstancesOf(AnnotationInterface::class, $injections);
@@ -58,12 +58,12 @@ class AnnotationExtractorTest extends TestCase
         $reader = $this->createMock(AnnotationReader::class);
         $reader->expects($this->exactly(3))
             ->method('getPropertyAnnotation')
-            ->with($this->isInstanceOf(ReflectionProperty::class), $this->equalTo(AnnotationInterface::class))
+            ->with($this->isInstanceOf(ReflectionProperty::class), AnnotationInterface::class)
             ->willReturn(null);
 
-        $extractor = new AnnotationExtractor($reader);
+        $annotationExtractor = new AnnotationExtractor($reader);
 
-        $injections = $extractor->getPropertiesInjections(ServiceAnnotation::class);
+        $injections = $annotationExtractor->getPropertiesInjections(ServiceAnnotation::class);
 
         self::assertCount(0, $injections);
     }
@@ -76,9 +76,9 @@ class AnnotationExtractorTest extends TestCase
             ->with($this->isInstanceOf(ReflectionMethod::class))
             ->willReturn([]);
 
-        $extractor = new AnnotationExtractor($reader);
+        $annotationExtractor = new AnnotationExtractor($reader);
 
-        $injections = $extractor->getConstructorInjections(ServiceAnnotation::class);
+        $injections = $annotationExtractor->getConstructorInjections(ServiceAnnotation::class);
 
         self::assertCount(0, $injections);
     }

--- a/test/Unit/Service/Extractor/AttributeExtractorTest.php
+++ b/test/Unit/Service/Extractor/AttributeExtractorTest.php
@@ -12,7 +12,7 @@ use Reinfi\DependencyInjection\Test\Service\Service2;
 use Reinfi\DependencyInjection\Test\Service\ServiceAttribute;
 use Reinfi\DependencyInjection\Test\Service\ServiceAttributeConstructor;
 
-class AttributeExtractorTest extends TestCase
+final class AttributeExtractorTest extends TestCase
 {
     public function testItResolvesPropertyAnnotations(): void
     {
@@ -22,9 +22,9 @@ class AttributeExtractorTest extends TestCase
             $this->markTestSkipped('Not a php version of 8.0 or above');
         }
 
-        $extractor = new AttributeExtractor();
+        $attributeExtractor = new AttributeExtractor();
 
-        $injections = $extractor->getPropertiesInjections(ServiceAttribute::class);
+        $injections = $attributeExtractor->getPropertiesInjections(ServiceAttribute::class);
 
         self::assertCount(3, $injections);
         self::assertContainsOnlyInstancesOf(InjectionInterface::class, $injections);
@@ -38,9 +38,9 @@ class AttributeExtractorTest extends TestCase
             $this->markTestSkipped('Not a php version of 8.0 or above');
         }
 
-        $extractor = new AttributeExtractor();
+        $attributeExtractor = new AttributeExtractor();
 
-        $injections = $extractor->getConstructorInjections(ServiceAttributeConstructor::class);
+        $injections = $attributeExtractor->getConstructorInjections(ServiceAttributeConstructor::class);
 
         self::assertCount(1, $injections);
         self::assertContainsOnlyInstancesOf(InjectionInterface::class, $injections);
@@ -48,9 +48,9 @@ class AttributeExtractorTest extends TestCase
 
     public function testItReturnsEmptyArrayIfNoConstructorIsDefined(): void
     {
-        $extractor = new AttributeExtractor();
+        $attributeExtractor = new AttributeExtractor();
 
-        $injections = $extractor->getConstructorInjections(Service2::class);
+        $injections = $attributeExtractor->getConstructorInjections(Service2::class);
 
         self::assertCount(0, $injections);
     }
@@ -63,9 +63,9 @@ class AttributeExtractorTest extends TestCase
             $this->markTestSkipped('Not a php version of 8.0 or above');
         }
 
-        $extractor = new AttributeExtractor();
+        $attributeExtractor = new AttributeExtractor();
 
-        $injections = $extractor->getConstructorInjections(Service1::class);
+        $injections = $attributeExtractor->getConstructorInjections(Service1::class);
 
         self::assertCount(0, $injections);
     }

--- a/test/Unit/Service/Extractor/ExtractorChainTest.php
+++ b/test/Unit/Service/Extractor/ExtractorChainTest.php
@@ -10,7 +10,7 @@ use Reinfi\DependencyInjection\Service\Extractor\ExtractorChain;
 use Reinfi\DependencyInjection\Service\Extractor\ExtractorInterface;
 use Reinfi\DependencyInjection\Test\Service\Service1;
 
-class ExtractorChainTest extends TestCase
+final class ExtractorChainTest extends TestCase
 {
     public function testItCallExtractorsForPropertyAnnotations(): void
     {
@@ -27,9 +27,9 @@ class ExtractorChainTest extends TestCase
             ->with(Service1::class)
             ->willReturn([]);
 
-        $extractor = new ExtractorChain([$extractor1, $extractor2]);
+        $extractorChain = new ExtractorChain([$extractor1, $extractor2]);
 
-        self::assertCount(0, $extractor->getPropertiesInjections(Service1::class));
+        self::assertCount(0, $extractorChain->getPropertiesInjections(Service1::class));
     }
 
     public function testItOnlyCallsOneExtractorIfInjectionsFoundInProperties(): void
@@ -47,9 +47,9 @@ class ExtractorChainTest extends TestCase
         $extractor2->expects($this->never())
             ->method('getPropertiesInjections');
 
-        $extractor = new ExtractorChain([$extractor1, $extractor2]);
+        $extractorChain = new ExtractorChain([$extractor1, $extractor2]);
 
-        self::assertCount(1, $extractor->getPropertiesInjections(Service1::class));
+        self::assertCount(1, $extractorChain->getPropertiesInjections(Service1::class));
     }
 
     public function testItCallsAllExtractorsForConstructorInjections(): void
@@ -67,9 +67,9 @@ class ExtractorChainTest extends TestCase
             ->with(Service1::class)
             ->willReturn([]);
 
-        $extractor = new ExtractorChain([$extractor1, $extractor2]);
+        $extractorChain = new ExtractorChain([$extractor1, $extractor2]);
 
-        self::assertCount(0, $extractor->getConstructorInjections(Service1::class));
+        self::assertCount(0, $extractorChain->getConstructorInjections(Service1::class));
     }
 
     public function testItOnlyCallsOneExtractorIfInjectionsFoundInConstructor(): void
@@ -87,8 +87,8 @@ class ExtractorChainTest extends TestCase
         $extractor2->expects($this->never())
             ->method('getConstructorInjections');
 
-        $extractor = new ExtractorChain([$extractor1, $extractor2]);
+        $extractorChain = new ExtractorChain([$extractor1, $extractor2]);
 
-        self::assertCount(1, $extractor->getConstructorInjections(Service1::class));
+        self::assertCount(1, $extractorChain->getConstructorInjections(Service1::class));
     }
 }

--- a/test/Unit/Service/Extractor/Factory/AnnotationExtractorFactoryTest.php
+++ b/test/Unit/Service/Extractor/Factory/AnnotationExtractorFactoryTest.php
@@ -12,14 +12,14 @@ use Reinfi\DependencyInjection\Service\Extractor\Factory\AnnotationExtractorFact
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Service\Extractor\Factory
  */
-class AnnotationExtractorFactoryTest extends TestCase
+final class AnnotationExtractorFactoryTest extends TestCase
 {
     public function testItReturnsAnnotationExtractor(): void
     {
         $container = $this->createMock(ContainerInterface::class);
 
-        $factory = new AnnotationExtractorFactory();
+        $annotationExtractorFactory = new AnnotationExtractorFactory();
 
-        self::assertInstanceOf(AnnotationExtractor::class, $factory($container));
+        self::assertInstanceOf(AnnotationExtractor::class, $annotationExtractorFactory($container));
     }
 }

--- a/test/Unit/Service/Extractor/Factory/ExtractorFactoryTest.php
+++ b/test/Unit/Service/Extractor/Factory/ExtractorFactoryTest.php
@@ -19,7 +19,7 @@ use Reinfi\DependencyInjection\Service\Extractor\YamlExtractor;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Service\Extractor\Factory
  */
-class ExtractorFactoryTest extends TestCase
+final class ExtractorFactoryTest extends TestCase
 {
     public function testItReturnsExtractorDefinedInConfig(): void
     {
@@ -33,32 +33,25 @@ class ExtractorFactoryTest extends TestCase
         $container = $this->createMock(ContainerInterface::class);
 
         $container->method('get')
-            ->willReturnCallback(function ($service) use (
-                $moduleConfig,
-                $yamlExtractor,
-                $annotationExtractor,
-                $attributeExtractor
-            ) {
-                return match ($service) {
-                    ModuleConfig::class => $moduleConfig->toArray(),
-                    YamlExtractor::class => $yamlExtractor,
-                    AnnotationExtractor::class => $annotationExtractor,
-                    AttributeExtractor::class => $attributeExtractor,
-                    default => null,
-                };
+            ->willReturnCallback(fn (string $service): mixed => match ($service) {
+                ModuleConfig::class => $moduleConfig->toArray(),
+                YamlExtractor::class => $yamlExtractor,
+                AnnotationExtractor::class => $annotationExtractor,
+                AttributeExtractor::class => $attributeExtractor,
+                default => null,
             });
 
-        $factory = new ExtractorFactory();
+        $extractorFactory = new ExtractorFactory();
 
-        $extractor = $factory($container);
+        $extractor = $extractorFactory($container);
 
         self::assertInstanceOf(ExtractorChain::class, $extractor);
 
         $reflectionClass = new ReflectionClass($extractor);
-        $chainProperty = $reflectionClass->getProperty('chain');
-        $chainProperty->setAccessible(true);
+        $reflectionProperty = $reflectionClass->getProperty('chain');
+        $reflectionProperty->setAccessible(true);
 
-        $chain = $chainProperty->getValue($extractor);
+        $chain = $reflectionProperty->getValue($extractor);
 
         self::assertTrue(is_array($chain));
 
@@ -79,32 +72,25 @@ class ExtractorFactoryTest extends TestCase
         $container = $this->createMock(ContainerInterface::class);
 
         $container->method('get')
-            ->willReturnCallback(function ($service) use (
-                $moduleConfig,
-                $yamlExtractor,
-                $annotationExtractor,
-                $attributeExtractor
-            ) {
-                return match ($service) {
-                    ModuleConfig::class => $moduleConfig->toArray(),
-                    YamlExtractor::class => $yamlExtractor,
-                    AnnotationExtractor::class => $annotationExtractor,
-                    AttributeExtractor::class => $attributeExtractor,
-                    default => null,
-                };
+            ->willReturnCallback(fn (string $service): mixed => match ($service) {
+                ModuleConfig::class => $moduleConfig->toArray(),
+                YamlExtractor::class => $yamlExtractor,
+                AnnotationExtractor::class => $annotationExtractor,
+                AttributeExtractor::class => $attributeExtractor,
+                default => null,
             });
 
-        $factory = new ExtractorFactory();
+        $extractorFactory = new ExtractorFactory();
 
-        $extractor = $factory($container);
+        $extractor = $extractorFactory($container);
 
         self::assertInstanceOf(ExtractorChain::class, $extractor);
 
         $reflectionClass = new ReflectionClass($extractor);
-        $chainProperty = $reflectionClass->getProperty('chain');
-        $chainProperty->setAccessible(true);
+        $reflectionProperty = $reflectionClass->getProperty('chain');
+        $reflectionProperty->setAccessible(true);
 
-        $chain = $chainProperty->getValue($extractor);
+        $chain = $reflectionProperty->getValue($extractor);
 
         self::assertTrue(is_array($chain));
 
@@ -122,26 +108,24 @@ class ExtractorFactoryTest extends TestCase
         $container = $this->createMock(ContainerInterface::class);
 
         $container->method('get')
-            ->willReturnCallback(function ($service) use ($moduleConfig, $annotationExtractor, $attributeExtractor) {
-                return match ($service) {
-                    ModuleConfig::class => $moduleConfig->toArray(),
-                    AnnotationExtractor::class => $annotationExtractor,
-                    AttributeExtractor::class => $attributeExtractor,
-                    default => null,
-                };
+            ->willReturnCallback(fn (string $service): mixed => match ($service) {
+                ModuleConfig::class => $moduleConfig->toArray(),
+                AnnotationExtractor::class => $annotationExtractor,
+                AttributeExtractor::class => $attributeExtractor,
+                default => null,
             });
 
-        $factory = new ExtractorFactory();
+        $extractorFactory = new ExtractorFactory();
 
-        $extractor = $factory($container);
+        $extractor = $extractorFactory($container);
 
         self::assertInstanceOf(ExtractorChain::class, $extractor);
 
         $reflectionClass = new ReflectionClass($extractor);
-        $chainProperty = $reflectionClass->getProperty('chain');
-        $chainProperty->setAccessible(true);
+        $reflectionProperty = $reflectionClass->getProperty('chain');
+        $reflectionProperty->setAccessible(true);
 
-        $chain = $chainProperty->getValue($extractor);
+        $chain = $reflectionProperty->getValue($extractor);
 
         self::assertTrue(is_array($chain));
 

--- a/test/Unit/Service/Extractor/Factory/YamlExtractorFactoryTest.php
+++ b/test/Unit/Service/Extractor/Factory/YamlExtractorFactoryTest.php
@@ -14,7 +14,7 @@ use Reinfi\DependencyInjection\Service\Extractor\YamlExtractor;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Service\Extractor\Factory
  */
-class YamlExtractorFactoryTest extends TestCase
+final class YamlExtractorFactoryTest extends TestCase
 {
     public function testItReturnsYamlExtractor(): void
     {
@@ -29,8 +29,8 @@ class YamlExtractorFactoryTest extends TestCase
             ->with(ModuleConfig::class)
             ->willReturn($moduleConfig);
 
-        $factory = new YamlExtractorFactory();
+        $yamlExtractorFactory = new YamlExtractorFactory();
 
-        self::assertInstanceOf(YamlExtractor::class, $factory($container));
+        self::assertInstanceOf(YamlExtractor::class, $yamlExtractorFactory($container));
     }
 }

--- a/test/Unit/Service/Extractor/YamlExtractorTest.php
+++ b/test/Unit/Service/Extractor/YamlExtractorTest.php
@@ -17,43 +17,43 @@ use Symfony\Component\Yaml\Yaml;
 /**
  * @package Reinfi\DependencyInjection\Test\Test\Unit\Service\Extractor
  */
-class YamlExtractorTest extends TestCase
+final class YamlExtractorTest extends TestCase
 {
     public function testItShouldReturnEmptyArrayForPropertyInjections(): void
     {
-        $extractor = new YamlExtractor(
+        $yamlExtractor = new YamlExtractor(
             new Yaml(),
             __DIR__ . '/../../../resources/services.yml',
             'Reinfi\DependencyInjection\Annotation'
         );
 
-        $injections = $extractor->getPropertiesInjections(Service1::class);
+        $injections = $yamlExtractor->getPropertiesInjections(Service1::class);
 
         self::assertCount(0, $injections);
     }
 
     public function testItShouldReturnInjections(): void
     {
-        $extractor = new YamlExtractor(
+        $yamlExtractor = new YamlExtractor(
             new Yaml(),
             __DIR__ . '/../../../resources/services.yml',
             'Reinfi\DependencyInjection\Annotation'
         );
 
-        $injections = $extractor->getConstructorInjections(Service1::class);
+        $injections = $yamlExtractor->getConstructorInjections(Service1::class);
 
         self::assertContainsOnlyInstancesOf(AnnotationInterface::class, $injections);
     }
 
     public function testItShouldSetRequiredInjectionProperties(): void
     {
-        $extractor = new YamlExtractor(
+        $yamlExtractor = new YamlExtractor(
             new Yaml(),
             __DIR__ . '/../../../resources/services.yml',
             'Reinfi\DependencyInjection\Annotation'
         );
 
-        $injections = $extractor->getConstructorInjections(Service1::class);
+        $injections = $yamlExtractor->getConstructorInjections(Service1::class);
 
         self::assertEquals(
             Service2::class,
@@ -64,26 +64,26 @@ class YamlExtractorTest extends TestCase
 
     public function testItShouldReturnInjectionsIfTypeHasConstructorArguments(): void
     {
-        $extractor = new YamlExtractor(
+        $yamlExtractor = new YamlExtractor(
             new Yaml(),
             __DIR__ . '/../../../resources/services.yml',
             'Reinfi\DependencyInjection\Annotation'
         );
 
-        $injections = $extractor->getConstructorInjections('Reinfi\DependencyInjection\Service\ServiceDoctrine');
+        $injections = $yamlExtractor->getConstructorInjections('Reinfi\DependencyInjection\Service\ServiceDoctrine');
 
         self::assertContainsOnlyInstancesOf(AnnotationInterface::class, $injections);
     }
 
     public function testItShouldReturnNoInjectionsIfNotDefined(): void
     {
-        $extractor = new YamlExtractor(
+        $yamlExtractor = new YamlExtractor(
             new Yaml(),
             __DIR__ . '/../../../resources/services.yml',
             'Reinfi\DependencyInjection\Annotation'
         );
 
-        $injections = $extractor->getConstructorInjections(Service2::class);
+        $injections = $yamlExtractor->getConstructorInjections(Service2::class);
 
         self::assertCount(0, $injections);
     }
@@ -92,38 +92,38 @@ class YamlExtractorTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $extractor = new YamlExtractor(
+        $yamlExtractor = new YamlExtractor(
             new Yaml(),
             __DIR__ . '/../../../resources/bad_services.yml',
             'Reinfi\DependencyInjection\Annotation'
         );
 
-        $extractor->getConstructorInjections(Service1::class);
+        $yamlExtractor->getConstructorInjections(Service1::class);
     }
 
     public function testItThrowsExceptionIfTypeIsUnknown(): void
     {
         $this->expectException(InjectionTypeUnknownException::class);
 
-        $extractor = new YamlExtractor(
+        $yamlExtractor = new YamlExtractor(
             new Yaml(),
             __DIR__ . '/../../../resources/bad_services.yml',
             'Reinfi\DependencyInjection\Annotation'
         );
 
-        $extractor->getConstructorInjections(Service2::class);
+        $yamlExtractor->getConstructorInjections(Service2::class);
     }
 
     public function testItThrowsExceptionIfTypeIsNotOfTypeInjectionInterface(): void
     {
         $this->expectException(InjectionTypeUnknownException::class);
 
-        $extractor = new YamlExtractor(
+        $yamlExtractor = new YamlExtractor(
             new Yaml(),
             __DIR__ . '/../../../resources/bad_services.yml',
             'Reinfi\DependencyInjection\Test\Service'
         );
 
-        $extractor->getConstructorInjections(ServiceAnnotation::class);
+        $yamlExtractor->getConstructorInjections(ServiceAnnotation::class);
     }
 }

--- a/test/Unit/Service/Factory/CacheServiceFactoryTest.php
+++ b/test/Unit/Service/Factory/CacheServiceFactoryTest.php
@@ -14,7 +14,7 @@ use Reinfi\DependencyInjection\Service\Factory\CacheServiceFactory;
 /**
  * @package Reinfi\DependencyInjection\Test\Unit\Service\Factory
  */
-class CacheServiceFactoryTest extends TestCase
+final class CacheServiceFactoryTest extends TestCase
 {
     public function testItInstancesCacheServiceWithoutConfig(): void
     {
@@ -25,13 +25,13 @@ class CacheServiceFactoryTest extends TestCase
             ->with(ModuleConfig::class)
             ->willReturn([]);
 
-        $factory = new CacheServiceFactory();
+        $cacheServiceFactory = new CacheServiceFactory();
 
-        $instance = $factory($container);
+        $cacheService = $cacheServiceFactory($container);
 
         self::assertInstanceOf(
             CacheService::class,
-            $instance,
+            $cacheService,
             'factory should return instance of ' . CacheService::class
         );
     }
@@ -42,25 +42,27 @@ class CacheServiceFactoryTest extends TestCase
 
         $container->expects($this->exactly(2))
             ->method('get')
-            ->willReturnCallback(function ($service) {
+            ->willReturnCallback(function ($service): array|Memory|null {
                 if ($service === ModuleConfig::class) {
                     return [
                         'cache' => Memory::class,
                     ];
                 }
+
                 if ($service === Memory::class) {
                     return new Memory();
                 }
+
                 return null;
             });
 
-        $factory = new CacheServiceFactory();
+        $cacheServiceFactory = new CacheServiceFactory();
 
-        $instance = $factory($container);
+        $cacheService = $cacheServiceFactory($container);
 
         self::assertInstanceOf(
             CacheService::class,
-            $instance,
+            $cacheService,
             'factory should return instance of ' . CacheService::class
         );
     }
@@ -73,19 +75,19 @@ class CacheServiceFactoryTest extends TestCase
             ->method('get')
             ->with(ModuleConfig::class)
             ->willReturn([
-                'cache' => static function (ContainerInterface $containerArgument) use ($container) {
+                'cache' => static function (ContainerInterface $containerArgument) use ($container): Memory {
                     self::assertSame($container, $containerArgument);
                     return new Memory();
                 },
             ]);
 
-        $factory = new CacheServiceFactory();
+        $cacheServiceFactory = new CacheServiceFactory();
 
-        $instance = $factory($container);
+        $cacheService = $cacheServiceFactory($container);
 
         self::assertInstanceOf(
             CacheService::class,
-            $instance,
+            $cacheService,
             'factory should return instance of ' . CacheService::class
         );
     }

--- a/test/Unit/Service/InjectionServiceTest.php
+++ b/test/Unit/Service/InjectionServiceTest.php
@@ -17,7 +17,7 @@ use Reinfi\DependencyInjection\Traits\CacheKeyTrait;
 /**
  * @package Reinfi\DependencyInjection\Test\Test\Unit\Service
  */
-class InjectionServiceTest extends TestCase
+final class InjectionServiceTest extends TestCase
 {
     use CacheKeyTrait;
 
@@ -51,11 +51,11 @@ class InjectionServiceTest extends TestCase
             ->with($cacheKey, $this->isArray())
             ->willReturn(true);
 
-        $service = new InjectionService($extractor, $cache);
+        $injectionService = new InjectionService($extractor, $cache);
 
         $container = $this->createMock(ContainerInterface::class);
 
-        $injections = $service->resolveConstructorInjection($container, Service1::class);
+        $injections = $injectionService->resolveConstructorInjection($container, Service1::class);
 
         self::assertCount(1, $injections);
     }
@@ -90,11 +90,11 @@ class InjectionServiceTest extends TestCase
             ->with($cacheKey, $this->isArray())
             ->willReturn(true);
 
-        $service = new InjectionService($extractor, $cache);
+        $injectionService = new InjectionService($extractor, $cache);
 
         $container = $this->createMock(ContainerInterface::class);
 
-        $injections = $service->resolveConstructorInjection($container, Service1::class);
+        $injections = $injectionService->resolveConstructorInjection($container, Service1::class);
 
         self::assertCount(1, $injections);
     }
@@ -120,11 +120,11 @@ class InjectionServiceTest extends TestCase
             ->with($cacheKey)
             ->willReturn([$injection]);
 
-        $service = new InjectionService($extractor, $cache);
+        $injectionService = new InjectionService($extractor, $cache);
 
         $container = $this->createMock(ContainerInterface::class);
 
-        $injections = $service->resolveConstructorInjection($container, Service1::class);
+        $injections = $injectionService->resolveConstructorInjection($container, Service1::class);
 
         self::assertCount(1, $injections);
     }
@@ -163,11 +163,11 @@ class InjectionServiceTest extends TestCase
             ->with($cacheKey, $this->isArray())
             ->willReturn(true);
 
-        $service = new InjectionService($extractor, $cache);
+        $injectionService = new InjectionService($extractor, $cache);
 
         $container = $this->createMock(ContainerInterface::class);
 
-        $injections = $service->resolveConstructorInjection($container, Service1::class);
+        $injections = $injectionService->resolveConstructorInjection($container, Service1::class);
 
         self::assertCount(1, $injections);
     }
@@ -195,11 +195,11 @@ class InjectionServiceTest extends TestCase
             ->with($cacheKey, $this->isArray())
             ->willReturn(true);
 
-        $service = new InjectionService($extractor, $cache);
+        $injectionService = new InjectionService($extractor, $cache);
 
         $container = $this->createMock(ContainerInterface::class);
 
-        $injections = $service->resolveConstructorInjection($container, Service2::class);
+        $injections = $injectionService->resolveConstructorInjection($container, Service2::class);
 
         self::assertFalse($injections);
     }

--- a/test/resources/application_config.php
+++ b/test/resources/application_config.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
-$modules = [\Reinfi\DependencyInjection\Module::class];
+use Reinfi\DependencyInjection\Module;
+
+$modules = [Module::class];
 
 if (class_exists('Laminas\Router\Module')) {
     $modules[] = 'Laminas\Router\Module';

--- a/test/resources/config.php
+++ b/test/resources/config.php
@@ -2,22 +2,32 @@
 
 declare(strict_types=1);
 
+use Laminas\ServiceManager\Factory\InvokableFactory;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use Reinfi\DependencyInjection\Factory\AutoWiringFactory;
+use Reinfi\DependencyInjection\Factory\InjectionFactory;
+use Reinfi\DependencyInjection\Test\Service\Factory\Service3Factory;
+use Reinfi\DependencyInjection\Test\Service\Service1;
+use Reinfi\DependencyInjection\Test\Service\Service2;
+use Reinfi\DependencyInjection\Test\Service\Service3;
+use Reinfi\DependencyInjection\Test\Service\ServiceAnnotation;
+use Reinfi\DependencyInjection\Test\Service\ServiceAnnotationConstructor;
+use Reinfi\DependencyInjection\Test\Service\ServiceBuildInTypeWithDefault;
+use Reinfi\DependencyInjection\Test\Service\ServiceBuildInTypeWithDefaultUsingConstant;
+use Reinfi\DependencyInjection\Test\Service\ServiceContainer;
 
 return [
     'service_manager' => [
         'factories' => [
-            \Reinfi\DependencyInjection\Test\Service\Service1::class => \Reinfi\DependencyInjection\Factory\AutoWiringFactory::class,
-            \Reinfi\DependencyInjection\Test\Service\Service2::class => \Laminas\ServiceManager\Factory\InvokableFactory::class,
-            \Reinfi\DependencyInjection\Test\Service\Service3::class => \Reinfi\DependencyInjection\Test\Service\Factory\Service3Factory::class,
-            \Reinfi\DependencyInjection\Test\Service\ServiceAnnotation::class => \Reinfi\DependencyInjection\Factory\InjectionFactory::class,
-            \Reinfi\DependencyInjection\Test\Service\ServiceAnnotationConstructor::class => \Reinfi\DependencyInjection\Factory\InjectionFactory::class,
-            \Reinfi\DependencyInjection\Test\Service\ServiceContainer::class => \Reinfi\DependencyInjection\Factory\AutoWiringFactory::class,
-            \Reinfi\DependencyInjection\Test\Service\ServiceBuildInTypeWithDefault::class => \Reinfi\DependencyInjection\Factory\AutoWiringFactory::class,
-            \Reinfi\DependencyInjection\Test\Service\ServiceBuildInTypeWithDefaultUsingConstant::class => \Reinfi\DependencyInjection\Factory\AutoWiringFactory::class,
-            'service_with_closure_as_factory' => function (ServiceLocatorInterface $locator) {
-                return new \stdClass();
-            },
+            Service1::class => AutoWiringFactory::class,
+            Service2::class => InvokableFactory::class,
+            Service3::class => Service3Factory::class,
+            ServiceAnnotation::class => InjectionFactory::class,
+            ServiceAnnotationConstructor::class => InjectionFactory::class,
+            ServiceContainer::class => AutoWiringFactory::class,
+            ServiceBuildInTypeWithDefault::class => AutoWiringFactory::class,
+            ServiceBuildInTypeWithDefaultUsingConstant::class => AutoWiringFactory::class,
+            'service_with_closure_as_factory' => fn (ServiceLocatorInterface $serviceLocator): stdClass => new stdClass(),
         ],
     ],
     'test' => [

--- a/test/resources/container.php
+++ b/test/resources/container.php
@@ -2,7 +2,8 @@
 
 declare(strict_types=1);
 
-return (static function (): Psr\Container\ContainerInterface {
-    return Laminas\Mvc\Application::init(require __DIR__ . '/application_config.php')
-        ->getServiceManager();
-})();
+use Laminas\Mvc\Application;
+use Psr\Container\ContainerInterface;
+
+return (static fn (): ContainerInterface => Application::init(require __DIR__ . '/application_config.php')
+    ->getServiceManager())();


### PR DESCRIPTION
I ran rector through the complete code, with a few skips within tests, because they broke the actual test cases.
Also skipped `StringClassNameToClassConstantRector` because that used imports where they should not have been used.