### PR TITLE
Remove dependency on `laminas/laminas-modulemanager` and related interface implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
     "require": {
         "php": "~8.3.0 || ~8.4.0",
         "laminas/laminas-servicemanager": "^3.23 | ^4.0",
-        "laminas/laminas-modulemanager": "^2.7",
         "psr/simple-cache": "^1.0 | ^2.0 | ^3.0"
     },
     "autoload": {

--- a/src/Module.php
+++ b/src/Module.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace Reinfi\DependencyInjection;
 
-use Laminas\ModuleManager\Feature\ConfigProviderInterface;
-
 /**
  * @package Reinfi\DependencyInjection
  */
-class Module implements ConfigProviderInterface
+class Module
 {
     public function getConfig(): array
     {


### PR DESCRIPTION
The interface is not required; the module can be loaded without it. In addition, further development on laminas-modulemanager will be discontinued shortly.